### PR TITLE
Fix slash commands exiting immediately when run without arguments

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -22,8 +22,11 @@ export interface SquireBackend {
   /** Launch an agent-based task in a terminal (or chat panel) */
   launchAgent(options: AgentLaunchOptions): void;
 
-  /** Launch a plain prompt task */
+  /** Launch a plain prompt task (single-shot, non-interactive) */
   launchPrompt(options: PromptLaunchOptions): void;
+
+  /** Launch a slash command interactively (not single-shot) */
+  launchInteractiveCommand(options: PromptLaunchOptions): void;
 
   /** Where to sync agent .md files for this backend */
   getAgentSyncDirs(location: 'home' | 'project', workspaceRoot: string): { agents: string; commands?: string };

--- a/src/backends/claude-code.ts
+++ b/src/backends/claude-code.ts
@@ -45,6 +45,11 @@ export class ClaudeCodeBackend implements SquireBackend {
     options.terminal.sendText(`claude -p "${sanitized}"`, true);
   }
 
+  launchInteractiveCommand(options: PromptLaunchOptions): void {
+    const sanitized = options.prompt.replace(/\n/g, ' ').replace(/"/g, '\\"');
+    options.terminal.sendText(`claude "${sanitized}"`, true);
+  }
+
   getAgentSyncDirs(location: 'home' | 'project', workspaceRoot: string): { agents: string; commands: string } {
     const base = location === 'project'
       ? path.join(workspaceRoot, '.claude')

--- a/src/backends/copilot-chat.ts
+++ b/src/backends/copilot-chat.ts
@@ -15,6 +15,10 @@ export class CopilotChatBackend implements SquireBackend {
     throw new Error('Copilot Chat backend is not yet implemented. Use copilot-cli or claude-code.');
   }
 
+  launchInteractiveCommand(_options: PromptLaunchOptions): void {
+    throw new Error('Copilot Chat backend is not yet implemented. Use copilot-cli or claude-code.');
+  }
+
   getAgentSyncDirs(_location: 'home' | 'project', _workspaceRoot: string): { agents: string } {
     throw new Error('Copilot Chat backend is not yet implemented.');
   }

--- a/src/backends/copilot-cli.ts
+++ b/src/backends/copilot-cli.ts
@@ -20,6 +20,12 @@ export class CopilotCliBackend implements SquireBackend {
     options.terminal.sendText(`copilot -i "${sanitized}" --allow-all`, true);
   }
 
+  launchInteractiveCommand(options: PromptLaunchOptions): void {
+    // Copilot CLI doesn't have a non-single-shot mode, so use the same approach
+    const sanitized = options.prompt.replace(/\n/g, ' ').replace(/"/g, '\\"');
+    options.terminal.sendText(`copilot -i "${sanitized}" --allow-all`, true);
+  }
+
   getAgentSyncDirs(location: 'home' | 'project', workspaceRoot: string): { agents: string } {
     if (location === 'project') {
       return { agents: path.join(workspaceRoot, '.github', 'copilot', 'agents') };

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -31,6 +31,8 @@ interface AgentLaunch {
   agent?: string;
   prompt?: string;
   initialPrompt?: string;
+  /** Slash command to run interactively (not single-shot) */
+  interactivePrompt?: string;
 }
 
 export class TaskRunner {
@@ -212,7 +214,14 @@ export class TaskRunner {
       createdAt: Date.now(),
     };
 
-    this.launchTerminal(taskInfo, { prompt: command }, this.workspaceRoot, terminalTitle, 'terminal');
+    // Slash commands run interactively (not single-shot) so the AI can
+    // prompt the user for missing arguments — matching dev-pilot behavior.
+    const isSlashCommand = command.startsWith('/');
+    if (isSlashCommand) {
+      this.launchTerminal(taskInfo, { interactivePrompt: command }, this.workspaceRoot, terminalTitle, 'terminal');
+    } else {
+      this.launchTerminal(taskInfo, { prompt: command }, this.workspaceRoot, terminalTitle, 'terminal');
+    }
     return taskInfo;
   }
 
@@ -309,6 +318,8 @@ export class TaskRunner {
 
     if (launch.agent) {
       this.backend.launchAgent({ terminal, agentName: launch.agent, initialPrompt: launch.initialPrompt });
+    } else if (launch.interactivePrompt) {
+      this.backend.launchInteractiveCommand({ terminal, prompt: launch.interactivePrompt });
     } else if (launch.prompt) {
       this.backend.launchPrompt({ terminal, prompt: launch.prompt });
     }


### PR DESCRIPTION
## Summary

- Added `launchInteractiveCommand` to the `SquireBackend` interface and implemented it across all backends (Claude Code, Copilot CLI, Copilot Chat)
- Updated `TaskRunner.runCommand()` to route slash commands through `launchInteractiveCommand` instead of `launchPrompt`, so the AI runs interactively and can prompt the user for missing arguments
- Added `interactivePrompt` field to the `AgentLaunch` interface

Fixes [#1](https://github.com/frankliu20/DevSquire/issues/1)

## Test plan
- [x] Build passes
- [ ] Manually run a slash command without arguments from the dashboard — verify the AI prompts for input instead of exiting immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)