### PR TITLE
feat(dashboard): add Run button for agent-based skills

### DIFF
--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -861,6 +861,7 @@ function renderSkills() {
       <div class="skill-desc">\${esc(s.description)}</div>
       <div class="skill-content" id="skill-\${esc(s.name)}">\${esc(s.content)}</div>
       \${s.type === 'command' ? '<button class="btn-s mt8" onclick="event.stopPropagation();runSkill(\\''+esc(s.name)+'\\')">Run</button>' : ''}
+      \${s.type === 'agent' && isRunnableAgent(s.name) ? '<button class="btn-s mt8" onclick="event.stopPropagation();promptRunAgent(\\''+esc(s.name)+'\\')">Run</button>' : ''}
     </div>\`).join('');
 }
 function toggleSkill(name) {
@@ -870,6 +871,18 @@ function toggleSkill(name) {
   });
 }
 function runSkill(name) { vscode.postMessage({ type: 'runCommand', command: '/' + name }); toast('Running /' + name, 'info'); }
+function isRunnableAgent(name) {
+  var runnable = ['squire-dev-issue', 'squire-watch-pr'];
+  return runnable.indexOf(name) !== -1;
+}
+function promptRunAgent(name) {
+  var placeholder = name === 'squire-dev-issue' ? 'Enter issue URL or description' : 'Enter PR URL (e.g. https://github.com/org/repo/pull/123)';
+  var input = prompt(placeholder);
+  if (input !== null && input.trim()) {
+    vscode.postMessage({ type: 'runAgent', agent: name, input: input.trim() });
+    toast('Launching ' + name + '...', 'info');
+  }
+}
 
 // ===== Report =====
 function switchReportView(v) {

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -102,6 +102,10 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
         this.taskRunner.runCommand(msg.command);
         break;
       }
+      case 'runAgent': {
+        this.taskRunner.runAgent(msg.agent, msg.input);
+        break;
+      }
       case 'killTask': {
         this.taskRunner.killTask(msg.taskId);
         break;

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -5,7 +5,7 @@ import { GitHubRepoInfo } from './github-detector';
 import { SquireDir } from './squire-dir';
 import { SquireBackend } from './backend';
 
-export type TaskType = 'dev-issue' | 'watch-pr' | 'review-pr' | 'fix-comments' | 'run-command';
+export type TaskType = 'dev-issue' | 'watch-pr' | 'review-pr' | 'fix-comments' | 'run-command' | 'run-agent';
 
 export interface TaskInfo {
   id: string;
@@ -196,6 +196,27 @@ export class TaskRunner {
     };
 
     this.launchTerminal(taskInfo, agentArgs, this.workspaceRoot, terminalTitle, 'wrench');
+    return taskInfo;
+  }
+
+  /** Run an agent-based skill from the dashboard with user input */
+  async runAgent(agentName: string, input: string): Promise<TaskInfo> {
+    const terminalTitle = `Squire: ${agentName}`;
+
+    const agentArgs: AgentLaunch = {
+      agent: agentName,
+      initialPrompt: input,
+    };
+
+    const taskInfo: TaskInfo = {
+      id: `agent-${Date.now()}`,
+      type: 'run-agent',
+      label: `${agentName}: ${input.substring(0, 60)}${input.length > 60 ? '…' : ''}`,
+      status: 'running',
+      createdAt: Date.now(),
+    };
+
+    this.launchTerminal(taskInfo, agentArgs, this.workspaceRoot, terminalTitle, 'squirrel');
     return taskInfo;
   }
 


### PR DESCRIPTION
## Summary
- Added Run button for agent-type skills (squire-dev-issue, squire-watch-pr) on the Skills page with input prompt
- Added `isRunnableAgent()` and `promptRunAgent()` helper functions in dashboard HTML
- Added `runAgent` message handler in dashboard provider delegating to `taskRunner.runAgent()`
- Added `run-agent` task type and `runAgent()` method in task runner that launches agent with user-provided input

## Test plan
- [x] Build passes (`npm run compile`)
- [ ] Open Skills page in VS Code, verify Run button appears for squire-dev-issue and squire-watch-pr
- [ ] Click Run button, verify input prompt appears
- [ ] Submit input, verify agent launches in terminal

Closes https://github.com/frankliu20/DevSquire/issues/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)