### PR TITLE
fix: use 'dev-adhoc' prefix in terminal title for ad-hoc dev-issue tasks

### DIFF
--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -82,7 +82,7 @@ export class TaskRunner {
 
     const terminalTitle = issueNum
       ? `Squire: Dev #${issueNum}`
-      : `Squire: adhoc-${Date.now()}`;
+      : `Squire: dev-adhoc-${Date.now()}`;
 
     const autoFlag = effectiveMode === 'auto' ? '--auto ' : '';
     const agentArgs: AgentLaunch = {


### PR DESCRIPTION
## Summary
- Changed ad-hoc dev-issue terminal title from `Squire: adhoc-<timestamp>` to `Squire: dev-adhoc-<timestamp>`

## Test plan
- [ ] Run dev-issue from skills/command panel without an issue URL — verify terminal title shows `Squire: dev-adhoc-xxx`
- [ ] Run dev-issue with an issue URL — verify terminal title still shows `Squire: Dev #<N>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)