### PR TITLE
fix(dashboard): persist worktree_dir in JSONL so Worktree button survives reload

### DIFF
--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -208,7 +208,8 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
     // Runtime tasks take priority, supplement with log data
     const merged = runtimeTasks.map((rt) => {
       const logTask = logTasks.find(
-        (lt) => lt.issueUrl === rt.issueUrl || lt.id === rt.id,
+        (lt) => lt.issueUrl === rt.issueUrl || lt.id === rt.id
+          || (rt.worktreeBranch && lt.branch === rt.worktreeBranch),
       );
       const phase = logTask?.phase || (rt.status === 'completed' ? 'done' : rt.status === 'running' ? 'implementing' : 'planned');
       const isWaiting = waitingTaskIds.has(rt.id) || waitingTaskIds.has(logTask?.id || '');
@@ -230,7 +231,9 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
 
     // Add log-only tasks not in runtime
     for (const lt of logTasks) {
-      if (!merged.find((m) => m.id === lt.id)) {
+      if (!merged.find((m) => m.id === lt.id
+        || (lt.issueUrl && runtimeTasks.some(rt => rt.issueUrl === lt.issueUrl))
+        || (lt.branch && runtimeTasks.some(rt => rt.worktreeBranch === lt.branch)))) {
         merged.push({
           id: lt.id,
           label: lt.issueNumber ? `Issue #${lt.issueNumber}` : lt.id,

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -329,6 +329,22 @@ export class TaskRunner {
       label: taskInfo.label,
     });
 
+    // Write per-task JSONL with worktree_dir so the dashboard can show the
+    // Worktree button even after the extension reloads (issue #7).
+    const issueNum = taskInfo.issueUrl?.match(/\/issues\/(\d+)/)?.[1];
+    const taskLogId = issueNum ? `task-issue-${issueNum}` : `task-${taskInfo.id}`;
+    this.squireDir.logJson(taskLogId, {
+      event: 'task_start',
+      phase: 'planned',
+      task_id: taskLogId,
+      type: taskInfo.type,
+      label: taskInfo.label,
+      branch: taskInfo.worktreeBranch,
+      issue_number: issueNum ? parseInt(issueNum) : undefined,
+      issue_url: taskInfo.issueUrl,
+      worktree_dir: taskInfo.worktreeDir,
+    });
+
     const terminal = vscode.window.createTerminal({
       name: terminalTitle,
       cwd,

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -55,7 +55,9 @@ export class TaskStateReader {
     if (!fs.existsSync(logsDir)) return [];
 
     const tasks: TaskState[] = [];
-    const files = fs.readdirSync(logsDir).filter((f) => f.endsWith('.jsonl') && f.startsWith('task-'));
+    const files = fs.readdirSync(logsDir).filter((f) =>
+      f.endsWith('.jsonl') && (f.startsWith('task-') || f.startsWith('issue-') || f.startsWith('adhoc-')),
+    );
 
     for (const file of files) {
       const taskId = file.replace('.jsonl', '');


### PR DESCRIPTION
## Summary

- **Root cause**: `launchTerminal()` stored `worktreeDir` in runtime memory only, never writing it to JSONL. After extension reload, the dashboard read from JSONL which had no `worktree_dir`, so the Worktree button was hidden.
- Write per-task JSONL log entry with `worktree_dir` field in `launchTerminal()` so worktree path persists across extension reloads
- Expand JSONL file filter in `readAllTasks()` to include `issue-*.jsonl` and `adhoc-*.jsonl` (written by Claude Code agents)
- Enhance runtime-to-log task matching to also match by branch name; improve dedup for log-only tasks

Fixes https://github.com/frankliu20/DevSquire/issues/7

## Test plan

- [x] Build passes (esbuild)
- [ ] Manual: run a dev-issue via Claude Code, reload extension, verify Worktree button appears in Tasks tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)