### PR TITLE
fix: use .squire/.gitignore instead of modifying project .gitignore

### DIFF
--- a/src/squire-dir.ts
+++ b/src/squire-dir.ts
@@ -28,19 +28,13 @@ export class SquireDir {
     this.ensureConfig();
   }
 
-  /** Add .squire/ to .gitignore if not already there */
+  /** Place a .gitignore inside .squire/ to ignore its own contents (never modify project .gitignore) */
   ensureGitignore(): void {
-    const gitignorePath = path.join(this.workspaceRoot, '.gitignore');
-    const entry = '.squire/';
+    const gitignorePath = path.join(this.dir, '.gitignore');
 
     try {
-      let content = '';
-      if (fs.existsSync(gitignorePath)) {
-        content = fs.readFileSync(gitignorePath, 'utf-8');
-      }
-      if (!content.includes(entry)) {
-        const section = `\n# DevSquire workspace data\n${entry}\n`;
-        fs.appendFileSync(gitignorePath, section);
+      if (!fs.existsSync(gitignorePath)) {
+        fs.writeFileSync(gitignorePath, '# Ignore everything in .squire/ except this file\n*\n!.gitignore\n');
       }
     } catch {
       // Non-critical — continue

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -77,7 +77,6 @@ export class TaskRunner {
 
     const branchName = issueNum ? `dev/issue-${issueNum}` : `dev/task-${Date.now()}`;
 
-    this.worktree.ensureGitignore(this.workspaceRoot);
     const wt = this.worktree.create(this.workspaceRoot, branchName);
 
     const terminalTitle = issueNum

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -89,26 +89,6 @@ export class WorktreeManager {
     }
   }
 
-  /**
-   * Ensure .squire/worktrees is in .gitignore
-   */
-  ensureGitignore(repoDir: string): void {
-    const gitignorePath = path.join(repoDir, '.gitignore');
-    const entry = '.squire/worktrees/';
-
-    try {
-      let content = '';
-      if (fs.existsSync(gitignorePath)) {
-        content = fs.readFileSync(gitignorePath, 'utf-8');
-      }
-      if (!content.includes(entry)) {
-        fs.appendFileSync(gitignorePath, `\n# DevSquire worktrees\n${entry}\n`);
-      }
-    } catch {
-      // Ignore
-    }
-  }
-
   private parseWorktreeList(output: string): WorktreeInfo[] {
     const worktrees: WorktreeInfo[] = [];
     let current: Partial<WorktreeInfo> = {};


### PR DESCRIPTION
## Summary
- Stop modifying the project's root `.gitignore` to add `.squire/`
- Instead, create `.squire/.gitignore` with `*` and `!.gitignore` entries to self-ignore
- Remove redundant `ensureGitignore()` from `WorktreeManager` and its call in `TaskRunner`

Fixes https://github.com/frankliu20/DevSquire/issues/18

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)