### PR TITLE
fix(dashboard): wire up action item click handlers

### DIFF
--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -309,9 +309,23 @@ export class TaskRunner {
   }
 
   focusTerminal(taskId: string): void {
+    // Direct lookup first
     const task = this.tasks.get(taskId);
     if (task?.terminal) {
       task.terminal.show();
+      return;
+    }
+    // Fallback: decision taskIds use "issue-<N>" format but TaskRunner uses
+    // "dev-<timestamp>".  Match by issue number in the task's issueUrl.
+    const issueMatch = taskId.match(/^issue-(\d+)$/);
+    if (issueMatch) {
+      const num = issueMatch[1];
+      for (const t of this.tasks.values()) {
+        if (t.terminal && t.issueUrl?.endsWith(`/issues/${num}`)) {
+          t.terminal.show();
+          return;
+        }
+      }
     }
   }
 

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -182,16 +182,36 @@ export class TaskStateReader {
   /** Dismiss a decision */
   dismissDecision(decisionId: string): boolean {
     const decisionsDir = path.join(this.squireDir, 'pending-decisions');
-    const filePath = path.join(decisionsDir, `${decisionId}.json`);
+    // Try direct filename match first (file named <id>.json)
+    const directPath = path.join(decisionsDir, `${decisionId}.json`);
     try {
-      if (fs.existsSync(filePath)) {
-        fs.unlinkSync(filePath);
+      if (fs.existsSync(directPath)) {
+        fs.unlinkSync(directPath);
         return true;
       }
-      return false;
     } catch {
-      return false;
+      // fall through to content search
     }
+    // Fallback: decision id may differ from filename (e.g. id "issue-21-<ts>"
+    // but file is "issue-21.json").  Scan files for matching id field.
+    try {
+      const files = fs.readdirSync(decisionsDir).filter((f) => f.endsWith('.json'));
+      for (const file of files) {
+        const fp = path.join(decisionsDir, file);
+        try {
+          const data = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+          if (data.id === decisionId) {
+            fs.unlinkSync(fp);
+            return true;
+          }
+        } catch {
+          // skip malformed
+        }
+      }
+    } catch {
+      // directory may not exist
+    }
+    return false;
   }
 
   /** Delete a task's log file */


### PR DESCRIPTION
## Summary

Fixes [#21](https://github.com/frankliu20/DevSquire/issues/21) — Clicking action items in the Actions tab does nothing.

- **`src/task-runner.ts`**: `focusTerminal()` now falls back to matching by issue number in `issueUrl` when the decision's `taskId` ("issue-N") doesn't match TaskRunner's internal id ("dev-\<timestamp\>")
- **`src/task-state.ts`**: `dismissDecision()` now scans file contents for matching `id` field when the decision id doesn't match the filename directly

## Test plan
- [x] Build passes
- [ ] Manually verify clicking action items in the Actions tab focuses the correct terminal
- [ ] Manually verify dismissing a decision removes the correct pending-decision file

🤖 Generated with [Claude Code](https://claude.com/claude-code)