### PR TITLE
fix(claude-code): use interactive mode for agent launches to prevent hanging

### DIFF
--- a/src/backends/claude-code.ts
+++ b/src/backends/claude-code.ts
@@ -29,9 +29,10 @@ export class ClaudeCodeBackend implements SquireBackend {
         true,
       );
     } else {
-      // Agents: launched via --agent flag
+      // Agents: launched in interactive mode (not single-shot -p) so the
+      // agent can make multiple tool calls without hanging.  See #24, #15.
       const prompt = options.initialPrompt
-        ? ` -p "${options.initialPrompt.replace(/"/g, '\\"')}"`
+        ? ` "${options.initialPrompt.replace(/"/g, '\\"')}"`
         : '';
       options.terminal.sendText(
         `claude --agent ${options.agentName}${prompt}`,


### PR DESCRIPTION
## Summary
- Removed `-p` flag from non-command agent launches in `src/backends/claude-code.ts`
- Previously, agents like `squire-pr-reviewer` were launched with `claude --agent <name> -p "prompt"` (single-shot mode), which hangs because complex agents need multiple tool calls
- Now launches with `claude --agent <name> "prompt"` (interactive mode), matching how dev-pilot handles it

## Test plan
- [x] Build passes (`npm run compile`)
- [ ] Manual: launch `squire-pr-reviewer` agent and verify it no longer hangs
- [ ] Manual: verify commands (non-agent) still use `-p` flag correctly

Closes https://github.com/frankliu20/DevSquire/issues/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)