### PR TITLE
fix(dashboard): align phase tracking with dev-pilot reference

### DIFF
--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -625,7 +625,7 @@ function issueTaskId(num) {
 }
 function phaseBadge(phase) {
   if (!phase) return '';
-  const map = { done: 'badge-green', failed: 'badge-red', orphan: 'badge-neutral', implementing: 'badge-yellow', testing: 'badge-yellow', exploring: 'badge-blue', analyzing: 'badge-blue', planning: 'badge-blue', creating_pr: 'badge-purple' };
+  const map = { done: 'badge-green', failed: 'badge-red', orphan: 'badge-neutral', planned: 'badge-neutral', implementing: 'badge-yellow', testing: 'badge-yellow', exploring: 'badge-blue', analyzing: 'badge-blue', planning: 'badge-blue', creating_pr: 'badge-purple' };
   const cls = Object.entries(map).find(([k]) => phase.includes(k))?.[1] || 'badge-neutral';
   return '<span class="badge ' + cls + '">' + esc(phase) + '</span>';
 }
@@ -796,10 +796,10 @@ function badgeFor(action) {
 
 // ===== Tasks =====
 function refreshTasks() { vscode.postMessage({ type: 'getTasks' }); }
-const PHASES = ['analyzing','exploring','planning','implementing','testing','creating_pr','done'];
-const PHASE_LABELS = { analyzing: 'Analyze', exploring: 'Explore', planning: 'Plan', implementing: 'Implement', testing: 'Build/Test', creating_pr: 'PR', done: 'Done' };
-// Map internal phases to pipeline display phases
-const PHASE_MAP = { planned: 'analyzing', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed' };
+const PHASES = ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'];
+const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyze', exploring: 'Explore', planning: 'Plan', implementing: 'Implement', testing: 'Build/Test', creating_pr: 'PR', done: 'Done' };
+// Map internal phases to pipeline display phases (12 internal → 8 display)
+const PHASE_MAP = { planned: 'planned', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed' };
 function renderTasks(list) {
   const c = document.getElementById('taskList');
   if (!list.length) { c.innerHTML = '<div class="empty" data-icon="⚙️">No active tasks</div>'; return; }

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -49,8 +49,13 @@ export interface PendingDecision {
  * which pipeline phase the task has reached, even if the agent didn't
  * explicitly set the phase field.
  */
-const EVENT_TYPE_TO_PHASE: Record<string, TaskPhase> = {
-  task_start: 'analyzing',
+/**
+ * Maps JSONL event types to pipeline phases.
+ * Returns undefined for non-phase-changing events (keeps previous phase).
+ * Aligned with dev-pilot's eventToPhase().
+ */
+const EVENT_TYPE_TO_PHASE: Record<string, TaskPhase | null> = {
+  task_start: 'planned',
   analysis_done: 'exploring',
   exploration_done: 'planning',
   plan_approved: 'implementing',
@@ -60,8 +65,26 @@ const EVENT_TYPE_TO_PHASE: Record<string, TaskPhase> = {
   manual_verify_waiting: 'waiting_manual_test',
   manual_verify_done: 'creating_pr',
   pr_created: 'done',
+  pr_merged: 'done',
+  worktree_cleaned: 'done',
+  skill_captured: 'done',
   blocked: 'failed',
+  // Non-phase-changing events — return null to keep previous phase
+  decision_requested: null,
+  decision_dismissed: null,
+  phase_change: null, // phase field will override
 };
+
+const VALID_PHASES: Set<string> = new Set([
+  'planned', 'analyzing', 'exploring', 'planning',
+  'implementing', 'testing', 'test_failed',
+  'waiting_confirm', 'waiting_manual_test',
+  'creating_pr', 'done', 'failed',
+]);
+
+function isValidPhase(value: string): boolean {
+  return VALID_PHASES.has(value);
+}
 
 /**
  * Reads task state from JSONL log files and pending decisions.
@@ -113,11 +136,34 @@ export class TaskStateReader {
           if (!startedAt) startedAt = entry.timestamp;
           updatedAt = entry.timestamp;
 
-          // Derive phase from event type if phase field is missing or generic
+          // Derive phase: event type mapping first, then phase field override
+          if (entry.type && entry.type in EVENT_TYPE_TO_PHASE) {
+            const mapped = EVENT_TYPE_TO_PHASE[entry.type];
+            if (mapped !== null) {
+              phase = mapped;
+            }
+            // null means non-phase-changing event — keep previous phase
+          }
+          // Phase field from the log entry can override (secondary mapping)
           if (entry.phase) {
-            phase = entry.phase;
-          } else if (entry.type && EVENT_TYPE_TO_PHASE[entry.type]) {
-            phase = EVENT_TYPE_TO_PHASE[entry.type];
+            const phaseMap: Record<string, TaskPhase> = {
+              branch_setup: 'planned',
+              analysis: 'analyzing',
+              exploration: 'exploring',
+              planning: 'planning',
+              implementation: 'implementing',
+              testing: 'testing',
+              pr_creation: 'creating_pr',
+              knowledge_capture: 'done',
+              completed: 'done',
+              failed: 'failed',
+            };
+            const remapped = phaseMap[entry.phase] as TaskPhase | undefined;
+            if (remapped !== undefined) {
+              phase = remapped;
+            } else if (isValidPhase(entry.phase)) {
+              phase = entry.phase as TaskPhase;
+            }
           }
           if (entry.branch) branch = entry.branch;
           if (entry.pr_number) prNumber = entry.pr_number;


### PR DESCRIPTION
## Summary
- Fixed event→phase mapping in `task-state.ts` to match dev-pilot reference implementation (`task_start` → `planned`, added `pr_merged`/`worktree_cleaned`/`skill_captured` → `done`, non-phase-changing events like `decision_requested`)
- Added secondary phase field mapping (e.g., `branch_setup` → `planned`, `analysis` → `analyzing`) matching dev-pilot's `deriveTasks()`
- Extended pipeline visualization in `dashboard-html.ts` from 7→8 steps by adding `planned` as the first step, with corresponding badge color

Closes [#26](https://github.com/frankliu20/DevSquire/issues/26)

## Test plan
- [x] Build passes
- [ ] Manual verify: confirm dashboard shows 8-step pipeline with `planned` phase
- [ ] Manual verify: confirm event-to-phase transitions match dev-pilot behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)