### PR TITLE
fix(dashboard): per-type progress pipelines for review-pr and watch-pr tasks

### DIFF
--- a/framework/agents/squire-pr-reviewer.md
+++ b/framework/agents/squire-pr-reviewer.md
@@ -247,3 +247,19 @@ When the user asks to fix a comment:
 4. **Strategy: normal → NEVER publish without explicit user confirmation**
 5. **Be concise** — no boilerplate, no filler
 6. **If the prompt says "NEVER publish"** — obey unconditionally, regardless of strategy
+
+## Status Logging
+
+At every phase transition, append a JSON line to `.squire/logs/task-review-<N>.jsonl`:
+```bash
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"task-review-<N>","type":"<event_type>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> ".squire/logs/task-review-<N>.jsonl"
+```
+
+Log at these points:
+| Event type | Phase | When |
+|-----------|-------|------|
+| `task_start` | `fetching` | Start of Step 1 — about to fetch PR data |
+| `fetch_done` | `reviewing` | PR data fetched, starting analysis |
+| `review_done` | `summarizing` | Analysis complete, presenting/publishing results |
+| `pr_created` | `done` | Review posted or presented to user |
+| `blocked` | `failed` | Unable to complete review |

--- a/framework/agents/squire-watch-pr.md
+++ b/framework/agents/squire-watch-pr.md
@@ -239,10 +239,23 @@ NOTIFICATION
 
 After every action, append a JSON line to the PR's log file:
 ```bash
-echo '{"timestamp":"<ISO8601>","task_id":"pr-<N>","type":"<event>","phase":"pr_monitor","pr_number":<N>,"detail":"<message>"}' >> ".squire/logs/pr-<N>.jsonl"
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"pr-<N>","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> ".squire/logs/pr-<N>.jsonl"
 ```
 
-Event types: `review_comments`, `ready_to_merge`, `pr_merged`, `ci_failure`, `ci_auto_fix`, `ci_auto_fix_failed`, `comment_auto_fix`, `comment_auto_fix_failed`, `auto_fix_blocked`
+Event types and phases:
+| Event type | Phase | When |
+|-----------|-------|------|
+| `task_start` | `analyzing` | Start of monitoring session |
+| `check_cycle` | `monitoring` | Each polling cycle starts |
+| `ci_failure` | `fixing_ci` | CI failure detected, about to auto-fix |
+| `ci_auto_fix` | `fixing_ci` | Auto-fix pushed for CI |
+| `ci_auto_fix_failed` | `fixing_ci` | Auto-fix failed for CI |
+| `review_comments` | `fixing_comments` | Unresolved comments detected, about to auto-fix |
+| `comment_auto_fix` | `fixing_comments` | Auto-fix pushed for comments |
+| `comment_auto_fix_failed` | `fixing_comments` | Auto-fix failed for comments |
+| `ready_to_merge` | `monitoring` | PR is ready to merge |
+| `pr_merged` | `done` | PR was merged/closed |
+| `auto_fix_blocked` | `failed` | Max attempts reached |
 
 ## Rules
 

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -840,7 +840,7 @@ function renderTasks(list) {
     const isFailed = rawPhase === 'failed' || rawPhase === 'test_failed';
     const phaseClass = rawPhase === 'done' ? 'done' : isFailed ? 'failed' : t.status === 'orphan' ? 'orphan' : t.status === 'running' ? 'running' : '';
     // For cyclic: show unique steps, only highlight current; for linear: show progress bar
-    const displayPhases = isCyclic ? phases : phases.filter(p => p !== 'done');
+    const displayPhases = isCyclic ? phases : (phases.length <= 2 ? phases : phases.filter(p => p !== 'done'));
     const pipeline = displayPhases.map((p, i) => {
       var cls = '';
       if (isCyclic) {

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -994,7 +994,7 @@ function runSkill(name) {
   vscode.postMessage({ type: 'runCommand', command: '/' + name }); toast('Running /' + name, 'info');
 }
 function isRunnableAgent(name) {
-  var runnable = ['squire-watch-pr'];
+  var runnable = ['squire-watch-pr', 'squire-dev-issue'];
   return runnable.indexOf(name) !== -1;
 }
 function promptRunAgent(name) {

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -990,7 +990,6 @@ function toggleSkill(name) {
   });
 }
 function runSkill(name) {
-  if (isRunnableAgent(name)) { promptRunAgent(name); return; }
   vscode.postMessage({ type: 'runCommand', command: '/' + name }); toast('Running /' + name, 'info');
 }
 function isRunnableAgent(name) {
@@ -1003,13 +1002,9 @@ function promptRunAgent(name) {
     toast('Launching Watch PRs...', 'info');
     return;
   }
-  if (name === 'squire-dev-issue') {
-    vscode.postMessage({ type: 'runAgent', agent: name, input: '' });
-    toast('Launching Dev Issue...', 'info');
-    return;
-  }
-  var placeholder = 'Enter input for ' + name;
-  vscode.postMessage({ type: 'promptInput', agent: name, placeholder: placeholder });
+  // Agent-type skills (e.g. Copilot backend) — launch directly
+  vscode.postMessage({ type: 'runAgent', agent: name, input: '' });
+  toast('Launching ' + name + '...', 'info');
 }
 
 // ===== Report =====

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -1003,7 +1003,12 @@ function promptRunAgent(name) {
     toast('Launching Watch PRs...', 'info');
     return;
   }
-  var placeholder = name === 'squire-dev-issue' ? 'Enter issue URL or description' : 'Enter input for ' + name;
+  if (name === 'squire-dev-issue') {
+    vscode.postMessage({ type: 'runAgent', agent: name, input: '' });
+    toast('Launching Dev Issue...', 'info');
+    return;
+  }
+  var placeholder = 'Enter input for ' + name;
   vscode.postMessage({ type: 'promptInput', agent: name, placeholder: placeholder });
 }
 

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -814,23 +814,44 @@ function badgeFor(action) {
 // ===== Tasks =====
 function refreshTasks() { vscode.postMessage({ type: 'getTasks' }); }
 const PHASES = ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'];
-const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyzing', exploring: 'Exploring', planning: 'Planning', implementing: 'Implementing', testing: 'Testing', creating_pr: 'Creating PR', done: 'Done' };
+const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyzing', exploring: 'Exploring', planning: 'Planning', implementing: 'Implementing', testing: 'Testing', creating_pr: 'Creating PR', done: 'Done', fetching: 'Fetch', reviewing: 'Review', summarizing: 'Summary', monitoring: 'Monitor', fixing_ci: 'Fix CI', fixing_comments: 'Fix Comments' };
 // Map internal phases to pipeline display phases
-const PHASE_MAP = { planned: 'planned', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed' };
+const PHASE_MAP = { planned: 'planned', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed', fetching: 'fetching', reviewing: 'reviewing', summarizing: 'summarizing', monitoring: 'monitoring', fixing_ci: 'fixing_ci', fixing_comments: 'fixing_comments' };
+// Per-type pipeline phases
+const PHASE_PIPELINES = {
+  'dev-issue':    ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'],
+  'review-pr':    ['fetching','reviewing','summarizing','done'],
+  'watch-pr':     ['analyzing','monitoring','fixing_ci','fixing_comments','monitoring'],
+  'fix-comments': ['analyzing','implementing','testing','creating_pr','done'],
+  'run-command':  ['implementing','done'],
+};
+// Cyclic pipelines only highlight current step (no "done" marking for previous steps)
+const CYCLIC_TYPES = { 'watch-pr': true };
 function renderTasks(list) {
   const c = document.getElementById('taskList');
   if (!list.length) { c.innerHTML = '<div class="empty" data-icon="⚙️">No active tasks</div>'; return; }
   c.innerHTML = list.map(t => {
+    const phases = PHASE_PIPELINES[t.type] || PHASE_PIPELINES['dev-issue'];
+    const isCyclic = CYCLIC_TYPES[t.type] || false;
     const rawPhase = t.phase || 'planned';
-    const displayPhase = PHASE_MAP[rawPhase] || 'analyzing';
-    const phaseIdx = PHASES.indexOf(displayPhase);
+    const displayPhase = PHASE_MAP[rawPhase] || phases[0];
+    // For cyclic pipelines, find the last occurrence to handle repeated phases (e.g. monitoring appears twice)
+    const phaseIdx = isCyclic ? phases.lastIndexOf(displayPhase) : phases.indexOf(displayPhase);
     const isFailed = rawPhase === 'failed' || rawPhase === 'test_failed';
     const phaseClass = rawPhase === 'done' ? 'done' : isFailed ? 'failed' : t.status === 'orphan' ? 'orphan' : t.status === 'running' ? 'running' : '';
-    const pipeline = PHASES.map((p, i) => {
+    // For cyclic: show unique steps, only highlight current; for linear: show progress bar
+    const displayPhases = isCyclic ? phases : phases.filter(p => p !== 'done');
+    const pipeline = displayPhases.map((p, i) => {
       var cls = '';
-      if (isFailed && i === phaseIdx) cls = 'failed';
-      else if (rawPhase === 'done' || i < phaseIdx) cls = 'done';
-      else if (i === phaseIdx && (t.status === 'running' || t.status === 'orphan')) cls = 'active';
+      if (isCyclic) {
+        // Cyclic: only highlight the current step, don't mark previous as done
+        if (isFailed && i === phaseIdx) cls = 'failed';
+        else if (i === phaseIdx && (t.status === 'running' || t.status === 'orphan')) cls = 'active';
+      } else {
+        if (isFailed && i === phaseIdx) cls = 'failed';
+        else if (rawPhase === 'done' || i < phaseIdx) cls = 'done';
+        else if (i === phaseIdx && (t.status === 'running' || t.status === 'orphan')) cls = 'active';
+      }
       return '<div class="pipeline-step ' + cls + '"><div class="pipeline-bar"></div><div class="pipeline-label">' + (PHASE_LABELS[p] || p) + '</div></div>';
     }).join('');
 

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -142,12 +142,7 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
       case 'promptInput': {
         const input = await vscode.window.showInputBox({ prompt: msg.placeholder, placeHolder: msg.placeholder });
         if (input?.trim()) {
-          // Route dev-issue through runDevIssue for proper worktree + task tracking
-          if (msg.agent === 'squire-dev-issue') {
-            this.taskRunner.runDevIssue(input.trim());
-          } else {
-            this.taskRunner.runAgent(msg.agent, input.trim());
-          }
+          this.taskRunner.runAgent(msg.agent, input.trim());
         }
         break;
       }

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -5,7 +5,7 @@ import { TaskRunner } from './task-runner';
 import { GitHubRepoInfo } from './github-detector';
 import { SquireDir } from './squire-dir';
 import { GitHubData } from './github-data';
-import { TaskStateReader } from './task-state';
+import { TaskStateReader, defaultRunningPhase } from './task-state';
 import { SkillsReader } from './skills-reader';
 import { ReportGenerator } from './report';
 import { getDashboardHtml } from './dashboard-html';
@@ -271,7 +271,7 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
         ),
       );
       if (logTask) claimedLogIds.add(logTask.id);
-      const phase = logTask?.phase || (rt.status === 'completed' ? 'done' : rt.status === 'running' ? 'implementing' : 'planned');
+      const phase = logTask?.phase || (rt.status === 'completed' ? 'done' : rt.status === 'running' ? defaultRunningPhase(rt.type) : 'planned');
       const isWaiting = waitingTaskIds.has(rt.id) || waitingTaskIds.has(logTask?.id || '');
       return {
         id: rt.id,

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -142,7 +142,12 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
       case 'promptInput': {
         const input = await vscode.window.showInputBox({ prompt: msg.placeholder, placeHolder: msg.placeholder });
         if (input?.trim()) {
-          this.taskRunner.runAgent(msg.agent, input.trim());
+          // Route dev-issue through runDevIssue for proper worktree + task tracking
+          if (msg.agent === 'squire-dev-issue') {
+            this.taskRunner.runDevIssue(input.trim());
+          } else {
+            this.taskRunner.runAgent(msg.agent, input.trim());
+          }
         }
         break;
       }

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -239,17 +239,20 @@ export class TaskRunner {
   /** Run a custom command or prompt — matches dashboard run-command */
   async runCommand(command: string): Promise<TaskInfo> {
     const adhocId = `dev-adhoc-${Date.now()}`;
+    const isDevIssue = command.includes('squire-dev-issue');
+    const isWatchPR = command.includes('squire-watch-pr');
     const label = command.startsWith('/')
       ? command.split(' ')[0]
       : command.substring(0, 40) + (command.length > 40 ? '…' : '');
-    const terminalTitle = command.startsWith('/')
-      ? `Squire: ${command.split(' ')[0]}`
+    const terminalTitle = isDevIssue ? `Squire: ${adhocId}`
+      : isWatchPR ? 'Squire: Watch PRs'
+      : command.startsWith('/') ? `Squire: ${command.split(' ')[0]}`
       : `Squire: ${adhocId}`;
 
     const taskInfo: TaskInfo = {
-      id: adhocId,
-      type: 'run-command',
-      label,
+      id: isWatchPR ? `watch-${Date.now()}` : adhocId,
+      type: isDevIssue ? 'dev-issue' : isWatchPR ? 'watch-pr' : 'run-command',
+      label: isDevIssue ? `[Auto] ${adhocId}` : isWatchPR ? 'Watch PRs' : label,
       status: 'running',
       createdAt: Date.now(),
     };

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -213,22 +213,26 @@ export class TaskRunner {
 
   /** Run an agent-based skill from the dashboard with user input */
   async runAgent(agentName: string, input: string): Promise<TaskInfo> {
-    const terminalTitle = `Squire: ${agentName}`;
+    const isDevIssue = agentName === 'squire-dev-issue';
+    const adhocId = `dev-adhoc-${Date.now()}`;
+    const terminalTitle = isDevIssue ? `Squire: ${adhocId}` : `Squire: ${agentName}`;
+    const taskId = isDevIssue ? adhocId : `agent-${Date.now()}`;
+    const taskType: TaskType = isDevIssue ? 'dev-issue' : 'run-agent';
 
     const agentArgs: AgentLaunch = {
       agent: agentName,
-      initialPrompt: input,
+      initialPrompt: input || undefined,
     };
 
     const taskInfo: TaskInfo = {
-      id: `agent-${Date.now()}`,
-      type: 'run-agent',
-      label: `${agentName}: ${input.substring(0, 60)}${input.length > 60 ? '…' : ''}`,
+      id: taskId,
+      type: taskType,
+      label: isDevIssue ? `[Auto] ${adhocId}` : `${agentName}: ${input.substring(0, 60)}${input.length > 60 ? '…' : ''}`,
       status: 'running',
       createdAt: Date.now(),
     };
 
-    this.launchTerminal(taskInfo, agentArgs, this.workspaceRoot, terminalTitle, 'squirrel');
+    this.launchTerminal(taskInfo, agentArgs, this.workspaceRoot, terminalTitle, isDevIssue ? 'rocket' : 'squirrel');
     return taskInfo;
   }
 

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -6,7 +6,34 @@ export type TaskPhase =
   | 'planned' | 'analyzing' | 'exploring' | 'planning'
   | 'implementing' | 'testing' | 'test_failed'
   | 'waiting_confirm' | 'waiting_manual_test'
-  | 'creating_pr' | 'done' | 'failed';
+  | 'creating_pr' | 'done' | 'failed'
+  // review-pr phases
+  | 'fetching' | 'reviewing' | 'summarizing'
+  // watch-pr phases
+  | 'monitoring' | 'fixing_ci' | 'fixing_comments';
+
+/** Pipeline phases displayed in the dashboard, per task type */
+export const PHASE_PIPELINES: Record<string, TaskPhase[]> = {
+  'dev-issue':    ['analyzing', 'exploring', 'planning', 'implementing', 'testing', 'creating_pr', 'done'],
+  'review-pr':    ['fetching', 'reviewing', 'summarizing', 'done'],
+  'watch-pr':     ['analyzing', 'monitoring', 'fixing_ci', 'fixing_comments', 'monitoring'],
+  'fix-comments': ['analyzing', 'implementing', 'testing', 'creating_pr', 'done'],
+  'run-command':  ['implementing', 'done'],
+};
+
+/** Task types that have a cyclic (non-linear) pipeline — only highlight current step, don't mark previous as done */
+export const CYCLIC_PIPELINES = new Set(['watch-pr']);
+
+/** Default fallback phase for a running task of the given type */
+export function defaultRunningPhase(taskType: string): TaskPhase {
+  switch (taskType) {
+    case 'review-pr':    return 'fetching';
+    case 'watch-pr':     return 'monitoring';
+    case 'fix-comments': return 'implementing';
+    case 'run-command':  return 'implementing';
+    default:             return 'implementing';
+  }
+}
 
 /** Derived from JSONL log entries */
 export interface TaskState {

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -93,6 +93,19 @@ const EVENT_TYPE_TO_PHASE: Record<string, TaskPhase> = {
   skill_captured: 'done',
   pr_merged: 'done',
   worktree_cleaned: 'done',
+  // review-pr events
+  fetch_done: 'reviewing',
+  review_done: 'summarizing',
+  // watch-pr events
+  check_cycle: 'monitoring',
+  ci_failure: 'fixing_ci',
+  ci_auto_fix: 'fixing_ci',
+  ci_auto_fix_failed: 'fixing_ci',
+  review_comments: 'fixing_comments',
+  comment_auto_fix: 'fixing_comments',
+  comment_auto_fix_failed: 'fixing_comments',
+  ready_to_merge: 'monitoring',
+  auto_fix_blocked: 'failed',
 };
 
 /**


### PR DESCRIPTION
## Summary
- review-pr and watch-pr tasks were stuck showing "implementing" phase because the dashboard hardcoded dev-issue phases for all task types
- Added per-type pipeline definitions: review-pr (Fetch→Review→Summary→Done), watch-pr (Analyze→Monitor→Fix CI→Fix Comments→Monitor as cyclic), fix-comments and run-command with appropriate phases
- Cyclic pipelines (watch-pr) only highlight the current step instead of marking previous steps as done

## Test plan
- [ ] Run a review-pr task and verify the pipeline shows Fetch→Review→Summary→Done
- [ ] Run watch-pr and verify it shows the cyclic pipeline with only the current step highlighted
- [ ] Run dev-issue and verify existing pipeline is unchanged
- [ ] Verify orphan/failed states still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)