### PR TITLE
feat(claude): add Claude-optimized commands with native orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .vscode-test/
 .squire/
 claude/
+!framework/commands/claude/
 CLAUDE.md
 .env*
 *.pem

--- a/framework/commands/claude/squire-dev-issue.md
+++ b/framework/commands/claude/squire-dev-issue.md
@@ -25,9 +25,9 @@ Strip `--auto` and `--test-scenario <id>` from input before processing.
 Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
 
 Use this ID for **ALL** logging:
-- JSONL file: `.squire/logs/<ID>.jsonl`
+- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
 - `task_id` field in all log entries: `<ID>`
-- Decision files: `.squire/pending-decisions/<ID>.json`
+- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
 
 If `[task-log-id:...]` is not provided, derive the ID:
 - Issue URL with number → `task-issue-<N>`
@@ -35,52 +35,53 @@ If `[task-log-id:...]` is not provided, derive the ID:
 
 ## Workspace
 
-Detect the repo slug from git remote:
+Detect the repo slug and **repo root** from git remote:
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
 
 All operations use `gh` CLI (GitHub only).
 - The current directory is the workspace root (or worktree).
-- Logs are stored under `.squire/logs/`.
+- **CRITICAL: Logs and decisions are ALWAYS written to `$REPO_ROOT/.squire/`** — the repo root, NOT the current working directory. After `EnterWorktree`, relative paths like `.squire/logs/` resolve inside the worktree, which is WRONG. Always use `"$REPO_ROOT/.squire/logs/"` and `"$REPO_ROOT/.squire/pending-decisions/"` for all log and decision file paths.
 - **Always `cd` into the correct worktree directory before running any git/build/test commands.**
 
 ## Status Logging — MANDATORY
 
 **You MUST run an echo command at every phase transition listed below. This is not optional. The dashboard depends on these logs to show progress.**
 
-Log file: `.squire/logs/$TASK_LOG_ID.jsonl`
+Log file: `$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl`
 
 **Run the first log IMMEDIATELY when you start, before any other work:**
 ```bash
-echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"task_start","phase":"analyzing","branch":"'"$BRANCH"'","detail":"Starting issue analysis"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"task_start","phase":"analyzing","branch":"'"$BRANCH"'","detail":"Starting issue analysis"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 ```
 
 Then log at each subsequent transition:
 ```bash
 # Phase 1 done:
-echo '{"timestamp":"...","task_id":"...","type":"analysis_done","phase":"exploring","branch":"...","detail":"Issue analyzed"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"analysis_done","phase":"exploring","branch":"...","detail":"Issue analyzed"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 2 done:
-echo '{"timestamp":"...","task_id":"...","type":"exploration_done","phase":"planning","branch":"...","detail":"Code explored"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"exploration_done","phase":"planning","branch":"...","detail":"Code explored"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 3 done:
-echo '{"timestamp":"...","task_id":"...","type":"plan_approved","phase":"implementing","branch":"...","detail":"Plan approved"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"plan_approved","phase":"implementing","branch":"...","detail":"Plan approved"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 4 done:
-echo '{"timestamp":"...","task_id":"...","type":"implementation_done","phase":"testing","branch":"...","detail":"Implementation complete"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"implementation_done","phase":"testing","branch":"...","detail":"Implementation complete"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 5 — tests passed:
-echo '{"timestamp":"...","task_id":"...","type":"test_pass","phase":"creating_pr","branch":"...","detail":"Tests passed"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"test_pass","phase":"creating_pr","branch":"...","detail":"Tests passed"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 5 — tests failed:
-echo '{"timestamp":"...","task_id":"...","type":"test_fail","phase":"testing","branch":"...","detail":"<error summary>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"test_fail","phase":"testing","branch":"...","detail":"<error summary>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Phase 6 — PR created:
-echo '{"timestamp":"...","task_id":"...","type":"pr_created","phase":"done","branch":"...","pr_number":N,"detail":"PR created"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"pr_created","phase":"done","branch":"...","pr_number":N,"detail":"PR created"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 
 # Blocked:
-echo '{"timestamp":"...","task_id":"...","type":"blocked","phase":"failed","branch":"...","detail":"<reason>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"...","task_id":"...","type":"blocked","phase":"failed","branch":"...","detail":"<reason>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 ```
 
 Replace all `...` with actual values. **Do not skip any of these logs.**
@@ -89,10 +90,10 @@ Replace all `...` with actual values. **Do not skip any of these logs.**
 
 **CRITICAL RULE**: Every time you stop and wait for user input — for ANY reason — you MUST write a decision notification file BEFORE prompting the user. The Dashboard will pop up a notification.
 
-1. **Write a decision request file** to `.squire/pending-decisions/$TASK_LOG_ID.json`:
+1. **Write a decision request file** to `$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json`:
 ```bash
-mkdir -p ".squire/pending-decisions"
-cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'DECISION'
+mkdir -p "$REPO_ROOT/.squire/pending-decisions"
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'DECISION'
 {
   "id": "$TASK_LOG_ID-<timestamp>",
   "taskId": "$TASK_LOG_ID",
@@ -107,7 +108,7 @@ DECISION
 
 2. **Also log** a `decision_requested` event to the JSONL file.
 
-3. **After user responds**, delete: `rm -f ".squire/pending-decisions/$TASK_LOG_ID.json"`
+3. **After user responds**, delete: `rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"`
 
 **Auto mode exception**: Never write decision requests — use defaults silently.
 

--- a/framework/commands/claude/squire-dev-issue.md
+++ b/framework/commands/claude/squire-dev-issue.md
@@ -93,15 +93,15 @@ Replace all `...` with actual values. **Do not skip any of these logs.**
 1. **Write a decision request file** to `$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json`:
 ```bash
 mkdir -p "$REPO_ROOT/.squire/pending-decisions"
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'DECISION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << DECISION
 {
-  "id": "$TASK_LOG_ID-<timestamp>",
+  "id": "$TASK_LOG_ID-$(date +%s)",
   "taskId": "$TASK_LOG_ID",
   "type": "decision",
   "title": "<short title>",
   "message": "<what you need from the user>",
   "options": ["option1", "option2"],
-  "createdAt": "<ISO8601>"
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 DECISION
 ```

--- a/framework/commands/claude/squire-dev-issue.md
+++ b/framework/commands/claude/squire-dev-issue.md
@@ -1,0 +1,324 @@
+---
+name: squire-dev-issue
+description: DevSquire agentic engineer — autonomously drives the full development lifecycle for a GitHub issue
+---
+
+You are the orchestrator of a DevSquire AI engineering team. The user will provide an issue link or issue description. Your job is to drive the complete development lifecycle using Claude Code's native orchestration primitives: Team, Tasks, Agents, and Worktrees.
+
+## Mode Detection
+
+Check if the user's prompt contains `--auto` (e.g., `/squire-dev-issue --auto https://github.com/.../issues/123`).
+
+- **Normal mode** (default): Run the full pipeline. Only stop for: (1) plan approval + test strategy, (2) unclear requirements, (3) test failures after 3 auto-fix rounds. Everything else proceeds automatically.
+- **Auto mode** (`--auto`): Zero stops. Defaults: test strategy 1 (build only), auto-approve plan. If anything fails after 3 auto-fix rounds, log `blocked` and stop.
+
+Also check for `--test-scenario <id>` where `<id>` matches a scenario defined by the user (e.g., `vscode`, `server`, etc.).
+
+- If `--test-scenario <id>` with known id → auto-select test strategy 3 with that scenario
+- If unknown id → warn and prompt as normal
+- In auto mode: `--test-scenario` is ignored, always strategy 1
+
+Strip `--auto` and `--test-scenario <id>` from input before processing.
+
+## Task Log ID
+
+Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+
+Use this ID for **ALL** logging:
+- JSONL file: `.squire/logs/<ID>.jsonl`
+- `task_id` field in all log entries: `<ID>`
+- Decision files: `.squire/pending-decisions/<ID>.json`
+
+If `[task-log-id:...]` is not provided, derive the ID:
+- Issue URL with number → `task-issue-<N>`
+- Plain text / adhoc → `task-adhoc-<date>`
+
+## Workspace
+
+Detect the repo slug from git remote:
+```bash
+REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+```
+
+All operations use `gh` CLI (GitHub only).
+- The current directory is the workspace root (or worktree).
+- Logs are stored under `.squire/logs/`.
+- **Always `cd` into the correct worktree directory before running any git/build/test commands.**
+
+## Status Logging — MANDATORY
+
+**You MUST run an echo command at every phase transition listed below. This is not optional. The dashboard depends on these logs to show progress.**
+
+Log file: `.squire/logs/$TASK_LOG_ID.jsonl`
+
+**Run the first log IMMEDIATELY when you start, before any other work:**
+```bash
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"task_start","phase":"analyzing","branch":"'"$BRANCH"'","detail":"Starting issue analysis"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+```
+
+Then log at each subsequent transition:
+```bash
+# Phase 1 done:
+echo '{"timestamp":"...","task_id":"...","type":"analysis_done","phase":"exploring","branch":"...","detail":"Issue analyzed"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 2 done:
+echo '{"timestamp":"...","task_id":"...","type":"exploration_done","phase":"planning","branch":"...","detail":"Code explored"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 3 done:
+echo '{"timestamp":"...","task_id":"...","type":"plan_approved","phase":"implementing","branch":"...","detail":"Plan approved"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 4 done:
+echo '{"timestamp":"...","task_id":"...","type":"implementation_done","phase":"testing","branch":"...","detail":"Implementation complete"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 5 — tests passed:
+echo '{"timestamp":"...","task_id":"...","type":"test_pass","phase":"creating_pr","branch":"...","detail":"Tests passed"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 5 — tests failed:
+echo '{"timestamp":"...","task_id":"...","type":"test_fail","phase":"testing","branch":"...","detail":"<error summary>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Phase 6 — PR created:
+echo '{"timestamp":"...","task_id":"...","type":"pr_created","phase":"done","branch":"...","pr_number":N,"detail":"PR created"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+
+# Blocked:
+echo '{"timestamp":"...","task_id":"...","type":"blocked","phase":"failed","branch":"...","detail":"<reason>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+```
+
+Replace all `...` with actual values. **Do not skip any of these logs.**
+
+## Decision Notifications
+
+**CRITICAL RULE**: Every time you stop and wait for user input — for ANY reason — you MUST write a decision notification file BEFORE prompting the user. The Dashboard will pop up a notification.
+
+1. **Write a decision request file** to `.squire/pending-decisions/$TASK_LOG_ID.json`:
+```bash
+mkdir -p ".squire/pending-decisions"
+cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'DECISION'
+{
+  "id": "$TASK_LOG_ID-<timestamp>",
+  "taskId": "$TASK_LOG_ID",
+  "type": "decision",
+  "title": "<short title>",
+  "message": "<what you need from the user>",
+  "options": ["option1", "option2"],
+  "createdAt": "<ISO8601>"
+}
+DECISION
+```
+
+2. **Also log** a `decision_requested` event to the JSONL file.
+
+3. **After user responds**, delete: `rm -f ".squire/pending-decisions/$TASK_LOG_ID.json"`
+
+**Auto mode exception**: Never write decision requests — use defaults silently.
+
+## Input
+
+The user provides ONE of:
+- A GitHub issue URL (e.g., `https://github.com/org/repo/issues/123`)
+- A GitHub issue reference (e.g., `#123` or `org/repo#123`)
+- A plain text issue description
+
+---
+
+## Step 1: Fetch & Analyze Issue
+
+### If given an issue URL or reference:
+```bash
+gh issue view <number> --repo $REPO_SLUG --json title,body,labels,comments,assignees,milestone
+```
+
+### If given plain text:
+Treat the user's text as the issue body. Use date-based task ID: `adhoc-<YYYYMMDD-HHMMSS>`.
+
+### Understand the issue:
+1. What is being asked? (bug fix, feature, refactor, etc.)
+2. What is the expected vs current behavior?
+3. Any constraints or requirements?
+4. Useful comments from others?
+
+**If unclear**: STOP and ask the user. **Auto mode**: Make best judgment and proceed.
+
+Output:
+```
+Issue #N: <title>
+Type: bug fix / feature / refactor / chore
+Summary: <1-2 sentences>
+Scope: <estimated files>
+```
+
+## Step 2: Enter Worktree
+
+Use `EnterWorktree` to create an isolated working copy:
+- Name: `issue-<N>` (or `adhoc-<date>` for plain text)
+
+This replaces manual `git worktree add`. The worktree is automatically managed by Claude Code.
+
+**From this point on, all git/build/test commands run inside the worktree.**
+
+Create the feature branch:
+```bash
+git checkout -b fix/issue-<N>  # or feat/issue-<N> for features
+```
+
+## Step 3: Create Team & Tasks
+
+Create a team to coordinate parallel agents:
+```
+TeamCreate(team_name="issue-<N>")
+```
+
+Create tasks with dependencies:
+```
+TaskCreate: "Explore codebase — find relevant files, architecture, tests"
+TaskCreate: "Implement changes" (blockedBy: explore)
+TaskCreate: "Test & fix" (blockedBy: implement)
+TaskCreate: "Create PR" (blockedBy: test)
+```
+
+## Step 4: Parallel Code Exploration
+
+Spawn **2-3 squire-code-explorer agents in parallel** (single message, multiple Agent calls):
+
+```
+Agent(subagent_type="squire-code-explorer", team_name="issue-<N>", name="explorer-1",
+      prompt="Find files directly related to: <issue summary>. Search by keywords, function names, error messages.")
+
+Agent(subagent_type="squire-code-explorer", team_name="issue-<N>", name="explorer-2",
+      prompt="Understand architecture around: <relevant area>. Trace imports, exports, dependencies.")
+
+Agent(subagent_type="squire-code-explorer", team_name="issue-<N>", name="explorer-3",  # if needed
+      prompt="Find related tests and understand test patterns for: <relevant area>.")
+```
+
+**These run in true parallel.** Wait for all to complete, then synthesize findings:
+```
+## Relevant Code
+- <file> — <why relevant>
+
+## Architecture Context
+- <how the code is structured>
+
+## Existing Tests
+- <test files covering this area>
+
+## Impact Analysis
+- <what else might be affected>
+```
+
+Mark explore task as completed.
+
+## Step 5: Implementation Plan + Test Strategy
+
+Based on exploration, create a plan:
+```
+## Implementation Plan for Issue #N
+
+### Changes Required
+1. <file> — <what and why>
+
+### New Files (if any)
+- <file> — <purpose>
+
+### Test Changes
+- <tests to add/modify>
+
+### Risks
+- <potential issues>
+```
+
+**Auto mode**: Skip prompt, use strategy 1, proceed to Step 6.
+
+**If `--test-scenario` provided**: Present plan, skip test strategy prompt, inform user of pre-selected strategy.
+
+**Otherwise**, write a decision notification file, then prompt:
+```
+Plan is ready. How should we verify the changes?
+
+1. Build only (default) — run build command
+2. Build + Impacted Tests — build + unit tests for changed files
+3. Build + Impacted Tests + Manual Verify — pick a test scenario
+
+Pick 1/2/3 (default: 1):
+```
+
+Wait for approval. If user just approves without picking, use strategy 1.
+
+## Step 6: Implementation
+
+Claim and start the implementation task. Implement according to the approved plan:
+- Follow existing code conventions
+- Write clean, well-commented code
+- Minimal changes — don't refactor unrelated code
+- Add/update tests if strategy 2 or 3
+
+Mark implementation task as completed.
+
+## Step 7: Test & Fix
+
+### Project Config (optional)
+
+Check if `.squire/config.yaml` exists. If it does, read it for user-specified overrides:
+```yaml
+build_command: "npm run build"
+test_command: "npm test"
+```
+
+If not found, auto-detect from project files (`package.json`, `pom.xml`, `Makefile`, `Cargo.toml`, `go.mod`, etc.).
+
+### Strategy 1 — Build Only (default):
+- Auto-detect or use configured build command
+- Build fails → auto-fix up to 3 rounds
+- Build passes → proceed
+
+### Strategy 2 — Build + Impacted Unit Tests:
+- Run build (same logic)
+- Detect test framework, run only tests related to changed files
+- Failures → auto-fix up to 3 rounds
+
+### Strategy 3 — Build + Tests + Manual Verify:
+- Run build + impacted tests (same as strategy 2)
+- Failures → auto-fix up to 3 rounds
+- All pass → write decision notification, wait for user "ok"
+
+**If auto-fix fails after 3 rounds**: STOP and report. **Auto mode**: log `blocked` and stop.
+
+Mark test task as completed.
+
+## Step 8: Create PR
+
+Spawn the **squire-pr-creator agent**:
+```
+Agent(subagent_type="squire-pr-creator", team_name="issue-<N>", name="pr-creator",
+      prompt="Create a PR for branch <branch-name>.
+        Issue: #<N> (https://github.com/<org>/<repo>/issues/<N>)
+        Changed files: <list>
+        Test results: Build ✅, Tests <✅|N/A>, Manual <✅|N/A>
+        Please stage, commit, push, and create the PR with issue reference.")
+```
+
+Wait for PR creator to complete. Mark PR task as completed.
+
+**Report the PR URL to the user.**
+
+## Step 9: Cleanup
+
+1. Shut down all teammates:
+```
+SendMessage(to="explorer-1", message={type: "shutdown_request"})
+SendMessage(to="explorer-2", message={type: "shutdown_request"})
+SendMessage(to="pr-creator", message={type: "shutdown_request"})
+```
+
+2. Clean up team: `TeamDelete`
+
+3. Keep worktree (may be needed for CI fixes or review comments). User can exit with `ExitWorktree` later.
+
+## Important Rules
+
+1. **Minimize interruptions** — only stop for: plan approval, unclear requirements, test failures after 3 rounds, manual verify. **Auto mode: zero stops.**
+2. **Stop on repeated failures** — if tests fail 3 times, report details and log `blocked`
+3. **Minimal changes** — only modify what's necessary
+4. **No force pushes, no pushing to main** — always use feature branches
+5. **Don't modify CI/CD configs** unless explicitly asked
+6. **Don't change dependency versions** unless explicitly asked
+7. **Reference the issue number** in commits and PR description

--- a/framework/commands/claude/squire-watch-pr.md
+++ b/framework/commands/claude/squire-watch-pr.md
@@ -1,0 +1,270 @@
+---
+name: squire-watch-pr
+description: DevSquire agentic engineer — monitors PRs and auto-fixes CI failures and review comments
+---
+
+You are a DevSquire PR monitoring daemon with auto-fix capabilities. **Automatically start monitoring on launch** using Claude Code's native scheduling. No need to ask the user.
+
+## Context
+
+- **Repo**: Detect from git remote: `REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')`. Monitor PRs for this repo.
+- **Scope**: Only my own PRs (`--author @me`).
+
+## Task Log ID
+
+Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+
+Use this ID for **ALL** logging:
+- JSONL file: `.squire/logs/<ID>.jsonl`
+- `task_id` field in all log entries: `<ID>`
+- Decision files: `.squire/pending-decisions/<ID>.json`
+
+If `[task-log-id:...]` is not provided, use `task-watch`.
+
+## Configuration
+
+The extension passes auto-fix settings in the initial prompt. Parse them:
+- `Auto-fix CI: on/off` → controls whether to auto-fix CI failures
+- `Auto-fix comments: on/off` → controls whether to auto-fix review comments
+
+Defaults if not provided: auto-fix CI = on, auto-fix comments = off.
+
+## Workspace
+
+The current directory is the workspace root. All operations use `gh` CLI (GitHub only).
+```bash
+REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+```
+
+## On Launch: Set Up Monitoring
+
+1. **Do the first check immediately** (see "Each Check" below).
+2. **Schedule recurring checks** using `CronCreate`:
+```
+CronCreate(
+  cron="*/10 * * * *",
+  prompt="Run PR monitoring check cycle: fetch my open PRs, detect CI failures, unresolved comments, or ready-to-merge status, auto-fix where enabled, and report changes. See /squire-watch-pr for full instructions.",
+  recurring=true
+)
+```
+3. **Report to user**:
+```
+PR Monitor started. Checking every 10 minutes (auto-expires after 7 days).
+Auto-fix CI: <on/off>  |  Auto-fix comments: <on/off>
+Cron job ID: <id> — cancel anytime with CronDelete.
+```
+
+**Note**: CronCreate jobs auto-expire after 7 days. For longer monitoring, the user needs to re-invoke.
+
+## Each Check Cycle
+
+### Step 1: Fetch my open PRs
+
+```bash
+gh pr list --repo $REPO_SLUG \
+  --author @me \
+  --state open \
+  --json number,title,reviewDecision,statusCheckRollup,headRefName,isDraft,url \
+  --limit 20
+```
+
+#### Fetch unresolved review threads:
+
+For each PR with `reviewDecision` of `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or `COMMENTED`:
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:50) {
+        nodes {
+          isResolved
+          comments(first:1) {
+            nodes { body author { login } createdAt }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
+```
+
+### Step 2: Detect THREE conditions
+
+| Condition | How to detect |
+|-----------|---------------|
+| **CI failure** | `statusCheckRollup` contains any check with `conclusion` of `FAILURE`, `ERROR`, `TIMED_OUT`, or `STARTUP_FAILURE` |
+| **New unresolved comments** | PR has unresolved review threads (`isResolved: false`) |
+| **Ready to merge** | `reviewDecision === "APPROVED"` AND all status checks pass AND not a draft |
+
+### Step 3: Compare with last check — only act on NEW changes
+
+Track state from the previous cycle. Only report/act when something **changed**:
+
+- **CI just failed** (was passing or pending before) → report + auto-fix if enabled
+- **New unresolved comments appeared** (count increased) → report + auto-fix if enabled
+- **PR just became ready to merge** (wasn't ready before) → report
+
+If nothing changed:
+```
+PR Monitor — <time> — no changes
+```
+
+### Step 4: Report (one line per PR, only if changes detected)
+
+```
+PR Monitor — <time>
+❌ #5130 Add retry logic — CI failed (build error) — auto-fixing...
+💬 #5124 Disable fail-fast — 3 unresolved comments
+✅ #5098 PostToolUse hook — approved & CI green, ready to merge!
+```
+
+If no open PRs:
+```
+PR Monitor — <time> — no open PRs
+```
+
+### Step 5: Auto-Fix Actions
+
+#### Auto-Fix State Tracking
+
+Maintain a counter per PR per fix type. Persist in `.squire/logs/auto-fix-state.json`:
+```json
+{
+  "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
+  "pr-456": { "ci_attempts": 2, "comment_attempts": 1 }
+}
+```
+- **Max 3 attempts** per PR per fix type. After 3 failed attempts, stop and notify user.
+- Reset counters when: PR is merged/closed, or CI goes green, or comments are resolved.
+
+#### CI Failure Auto-Fix (when `auto_fix_ci: true`)
+
+Only trigger when CI **newly failed** (not already failing from last cycle with same error).
+
+1. **Invoke `/squire-dev-issue --auto`**:
+```
+/squire-dev-issue --auto Fix failing CI on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Diagnose the CI failure and push a fix.
+```
+
+2. **After completion**: increment `ci_attempts`, log event, update notification.
+
+3. **If max attempts (3) reached**: write notification asking user to intervene, log `auto_fix_blocked`, stop auto-fixing this PR's CI.
+
+#### Review Comments Auto-Fix (when `auto_fix_comments: true`)
+
+Only trigger when **new** unresolved comments appear (count increased since last cycle).
+
+1. **Invoke `/squire-dev-issue --auto`**:
+```
+/squire-dev-issue --auto Address unresolved review comments on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Read the comments, fix the code, and push.
+```
+
+2. **After completion**: increment `comment_attempts`, log event.
+
+3. **If max attempts (3) reached**: same as CI — notify user and stop.
+
+## Dashboard Notifications
+
+When a condition is detected and it's NEW (changed since last cycle), write a notification file:
+
+```bash
+mkdir -p ".squire/pending-decisions"
+```
+
+### For CI failure:
+```bash
+cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+{
+  "taskId": "$TASK_LOG_ID",
+  "issueNumber": null,
+  "prNumber": <N>,
+  "phase": "pr_notification",
+  "question": "PR #<N> CI failed: <failure summary>",
+  "options": ["Auto-fixing...", "Review Logs", "Dismiss"],
+  "context": "<failed job names and brief error>",
+  "timestamp": "<ISO8601>"
+}
+NOTIFICATION
+```
+
+### For unresolved comments:
+```bash
+cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+{
+  "taskId": "$TASK_LOG_ID",
+  "issueNumber": null,
+  "prNumber": <N>,
+  "phase": "pr_notification",
+  "question": "PR #<N> has <count> unresolved review comments",
+  "options": ["Fix Comments", "Review", "Dismiss"],
+  "context": "<reviewer names and first line of each unresolved comment>",
+  "timestamp": "<ISO8601>"
+}
+NOTIFICATION
+```
+
+### For ready to merge:
+```bash
+cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+{
+  "taskId": "$TASK_LOG_ID",
+  "issueNumber": null,
+  "prNumber": <N>,
+  "phase": "pr_notification",
+  "question": "PR #<N> is approved and CI green — ready to merge!",
+  "options": ["Merge", "Review", "Dismiss"],
+  "context": "<PR title, approver names>",
+  "timestamp": "<ISO8601>"
+}
+NOTIFICATION
+```
+
+### Cleanup notifications:
+- PR merged/closed → **auto-cleanup**:
+  1. Delete notification: `rm -f ".squire/pending-decisions/$TASK_LOG_ID.json"`
+  2. Remove auto-fix state for this PR from `auto-fix-state.json`
+  3. Find and remove the worktree for this PR's branch
+  4. Log `pr_merged` event
+- CI goes green → reset `ci_attempts` to 0
+- Unresolved comments drop to 0 → delete notification, reset `comment_attempts`
+- Same PR already has notification → overwrite with latest state
+
+## Status Logging
+
+After every action, append a JSON line to the task's log file:
+```bash
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+```
+
+Event types and phases:
+| Event type | Phase | When |
+|-----------|-------|------|
+| `task_start` | `analyzing` | Start of monitoring session |
+| `check_cycle` | `monitoring` | Each polling cycle starts |
+| `ci_failure` | `fixing_ci` | CI failure detected |
+| `ci_auto_fix` | `fixing_ci` | Auto-fix pushed for CI |
+| `ci_auto_fix_failed` | `fixing_ci` | Auto-fix failed for CI |
+| `review_comments` | `fixing_comments` | Unresolved comments detected |
+| `comment_auto_fix` | `fixing_comments` | Auto-fix pushed for comments |
+| `comment_auto_fix_failed` | `fixing_comments` | Auto-fix failed for comments |
+| `ready_to_merge` | `monitoring` | PR is ready to merge |
+| `pr_merged` | `done` | PR was merged/closed |
+| `auto_fix_blocked` | `failed` | Max attempts reached |
+
+## Rules
+
+1. **Start immediately** — no confirmation needed
+2. **10-minute interval** via CronCreate — fires only when session is idle
+3. **Three conditions** — CI failure, unresolved comments, and ready-to-merge
+4. **Only elaborate on changes** — don't repeat known status
+5. **Never auto-merge** — only notify
+6. **My PRs only** — ignore other people's PRs
+7. **Auto-fix delegates to `/squire-dev-issue --auto`** — reuses existing worktrees, full fix pipeline
+8. **Auto-fix CI is on by default** — configure via VS Code setting `devSquire.watchPR.autoFixCI`
+9. **Auto-fix comments is off by default** — configure via VS Code setting `devSquire.watchPR.autoFixComments`
+10. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
+11. **Never force push** — all fixes are new commits
+12. **Log all auto-fix actions** — every fix attempt is logged
+13. **Notifications are fire-and-forget** — don't wait for terminal input
+14. **CronCreate auto-expires after 7 days** — user must re-invoke for longer monitoring

--- a/framework/commands/claude/squire-watch-pr.md
+++ b/framework/commands/claude/squire-watch-pr.md
@@ -177,7 +177,7 @@ mkdir -p "$REPO_ROOT/.squire/pending-decisions"
 
 ### For CI failure:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,
@@ -193,7 +193,7 @@ NOTIFICATION
 
 ### For unresolved comments:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,
@@ -209,7 +209,7 @@ NOTIFICATION
 
 ### For ready to merge:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,

--- a/framework/commands/claude/squire-watch-pr.md
+++ b/framework/commands/claude/squire-watch-pr.md
@@ -15,9 +15,9 @@ You are a DevSquire PR monitoring daemon with auto-fix capabilities. **Automatic
 Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
 
 Use this ID for **ALL** logging:
-- JSONL file: `.squire/logs/<ID>.jsonl`
+- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
 - `task_id` field in all log entries: `<ID>`
-- Decision files: `.squire/pending-decisions/<ID>.json`
+- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
 
 If `[task-log-id:...]` is not provided, use `task-watch`.
 
@@ -34,7 +34,10 @@ Defaults if not provided: auto-fix CI = on, auto-fix comments = off.
 The current directory is the workspace root. All operations use `gh` CLI (GitHub only).
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
+
+**CRITICAL: All log and decision paths MUST use `$REPO_ROOT/.squire/`** — not relative `.squire/`. After `cd` into a worktree, relative paths resolve inside the worktree, making logs invisible to the Dashboard.
 
 ## On Launch: Set Up Monitoring
 
@@ -128,7 +131,7 @@ PR Monitor — <time> — no open PRs
 
 #### Auto-Fix State Tracking
 
-Maintain a counter per PR per fix type. Persist in `.squire/logs/auto-fix-state.json`:
+Maintain a counter per PR per fix type. Persist in `$REPO_ROOT/.squire/logs/auto-fix-state.json`:
 ```json
 {
   "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
@@ -169,12 +172,12 @@ Only trigger when **new** unresolved comments appear (count increased since last
 When a condition is detected and it's NEW (changed since last cycle), write a notification file:
 
 ```bash
-mkdir -p ".squire/pending-decisions"
+mkdir -p "$REPO_ROOT/.squire/pending-decisions"
 ```
 
 ### For CI failure:
 ```bash
-cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,
@@ -190,7 +193,7 @@ NOTIFICATION
 
 ### For unresolved comments:
 ```bash
-cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,
@@ -206,7 +209,7 @@ NOTIFICATION
 
 ### For ready to merge:
 ```bash
-cat > ".squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
+cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
 {
   "taskId": "$TASK_LOG_ID",
   "issueNumber": null,
@@ -222,7 +225,7 @@ NOTIFICATION
 
 ### Cleanup notifications:
 - PR merged/closed → **auto-cleanup**:
-  1. Delete notification: `rm -f ".squire/pending-decisions/$TASK_LOG_ID.json"`
+  1. Delete its notification: `rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"`
   2. Remove auto-fix state for this PR from `auto-fix-state.json`
   3. Find and remove the worktree for this PR's branch
   4. Log `pr_merged` event
@@ -234,7 +237,7 @@ NOTIFICATION
 
 After every action, append a JSON line to the task's log file:
 ```bash
-echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> ".squire/logs/$TASK_LOG_ID.jsonl"
+echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
 ```
 
 Event types and phases:

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -4,6 +4,16 @@ import * as os from 'os';
 
 export type BackendType = 'copilot-cli' | 'claude-code' | 'copilot-chat';
 
+/**
+ * Agent names that are installed as commands (slash commands) rather than agents
+ * for backends that support separate command directories (e.g., Claude Code).
+ */
+export const COMMAND_AGENT_NAMES = new Set([
+  'squire-dev-issue',
+  'squire-watch-pr',
+  'squire-pr-reviewer',
+]);
+
 export interface AgentLaunchOptions {
   terminal: vscode.Terminal;
   agentName: string;

--- a/src/backends/claude-code.ts
+++ b/src/backends/claude-code.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as os from 'os';
-import { SquireBackend, AgentLaunchOptions, PromptLaunchOptions } from '../backend';
+import { SquireBackend, AgentLaunchOptions, PromptLaunchOptions, COMMAND_AGENT_NAMES } from '../backend';
 
 /**
  * Claude Code backend.
@@ -14,15 +14,8 @@ import { SquireBackend, AgentLaunchOptions, PromptLaunchOptions } from '../backe
 export class ClaudeCodeBackend implements SquireBackend {
   readonly type = 'claude-code' as const;
 
-  /** Agent names that are synced as commands (triggered via /name) */
-  private static readonly COMMAND_AGENTS = new Set([
-    'squire-dev-issue',
-    'squire-watch-pr',
-    'squire-pr-reviewer',
-  ]);
-
   launchAgent(options: AgentLaunchOptions): void {
-    if (ClaudeCodeBackend.COMMAND_AGENTS.has(options.agentName)) {
+    if (COMMAND_AGENT_NAMES.has(options.agentName)) {
       // Commands: launched via slash command
       const prompt = options.initialPrompt ? ` ${options.initialPrompt}` : '';
       options.terminal.sendText(

--- a/src/framework-sync.ts
+++ b/src/framework-sync.ts
@@ -29,17 +29,40 @@ export class FrameworkSync {
     }
 
     const targetDirs = this.backend.getAgentSyncDirs(location, workspaceRoot || '');
-    const srcDir = path.join(this.bundledDir, 'agents');
+    const agentsSrcDir = path.join(this.bundledDir, 'agents');
+
+    // Backend-specific commands directory (e.g., framework/commands/claude/)
+    const commandsSrcDir = path.join(this.bundledDir, 'commands', this.backend.type);
+    const hasBackendCommands = fs.existsSync(commandsSrcDir);
+
     let synced = 0;
 
     if (targetDirs.commands) {
       // Backend has separate commands dir — split files by COMMAND_AGENTS list
       const commandNames = new Set(['squire-dev-issue', 'squire-watch-pr', 'squire-pr-reviewer']);
-      synced += this.syncDir(srcDir, targetDirs.commands, (f) => commandNames.has(f.replace('.md', '')));
-      synced += this.syncDir(srcDir, targetDirs.agents, (f) => !commandNames.has(f.replace('.md', '')));
+
+      if (hasBackendCommands) {
+        // Prefer backend-specific command files, fall back to generic agents
+        synced += this.syncDir(commandsSrcDir, targetDirs.commands);
+        // Also sync any command agents that don't have a backend-specific version
+        const backendCommandFiles = new Set(
+          fs.existsSync(commandsSrcDir)
+            ? fs.readdirSync(commandsSrcDir).filter((f) => f.endsWith('.md')).map((f) => f.replace('.md', ''))
+            : [],
+        );
+        synced += this.syncDir(agentsSrcDir, targetDirs.commands, (f) =>
+          commandNames.has(f.replace('.md', '')) && !backendCommandFiles.has(f.replace('.md', '')),
+        );
+      } else {
+        // No backend-specific commands — use generic agent files as commands
+        synced += this.syncDir(agentsSrcDir, targetDirs.commands, (f) => commandNames.has(f.replace('.md', '')));
+      }
+
+      // Non-command agents always come from framework/agents/
+      synced += this.syncDir(agentsSrcDir, targetDirs.agents, (f) => !commandNames.has(f.replace('.md', '')));
     } else {
-      // All go to agents dir
-      synced += this.syncDir(srcDir, targetDirs.agents);
+      // All go to agents dir (e.g., Copilot backend)
+      synced += this.syncDir(agentsSrcDir, targetDirs.agents);
     }
 
     if (showNotification) {

--- a/src/framework-sync.ts
+++ b/src/framework-sync.ts
@@ -10,6 +10,17 @@ import { SquireBackend } from './backend';
 export class FrameworkSync {
   private readonly bundledDir: string;
 
+  /**
+   * Agent names that should be synced as commands (not agents) for backends
+   * that support a separate commands directory (e.g., Claude Code).
+   * Keep in sync with ClaudeCodeBackend.COMMAND_AGENTS.
+   */
+  private static readonly COMMAND_NAMES = new Set([
+    'squire-dev-issue',
+    'squire-watch-pr',
+    'squire-pr-reviewer',
+  ]);
+
   constructor(
     private context: vscode.ExtensionContext,
     private backend: SquireBackend,
@@ -38,17 +49,14 @@ export class FrameworkSync {
     let synced = 0;
 
     if (targetDirs.commands) {
-      // Backend has separate commands dir — split files by COMMAND_AGENTS list
-      const commandNames = new Set(['squire-dev-issue', 'squire-watch-pr', 'squire-pr-reviewer']);
+      const commandNames = FrameworkSync.COMMAND_NAMES;
 
       if (hasBackendCommands) {
         // Prefer backend-specific command files, fall back to generic agents
         synced += this.syncDir(commandsSrcDir, targetDirs.commands);
         // Also sync any command agents that don't have a backend-specific version
         const backendCommandFiles = new Set(
-          fs.existsSync(commandsSrcDir)
-            ? fs.readdirSync(commandsSrcDir).filter((f) => f.endsWith('.md')).map((f) => f.replace('.md', ''))
-            : [],
+          fs.readdirSync(commandsSrcDir).filter((f) => f.endsWith('.md')).map((f) => f.replace('.md', '')),
         );
         synced += this.syncDir(agentsSrcDir, targetDirs.commands, (f) =>
           commandNames.has(f.replace('.md', '')) && !backendCommandFiles.has(f.replace('.md', '')),

--- a/src/framework-sync.ts
+++ b/src/framework-sync.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { SquireBackend } from './backend';
+import { SquireBackend, COMMAND_AGENT_NAMES } from './backend';
 
 /**
  * Syncs DevSquire agent .md files to the backend's agent directory.
@@ -9,17 +9,6 @@ import { SquireBackend } from './backend';
  */
 export class FrameworkSync {
   private readonly bundledDir: string;
-
-  /**
-   * Agent names that should be synced as commands (not agents) for backends
-   * that support a separate commands directory (e.g., Claude Code).
-   * Keep in sync with ClaudeCodeBackend.COMMAND_AGENTS.
-   */
-  private static readonly COMMAND_NAMES = new Set([
-    'squire-dev-issue',
-    'squire-watch-pr',
-    'squire-pr-reviewer',
-  ]);
 
   constructor(
     private context: vscode.ExtensionContext,
@@ -49,18 +38,32 @@ export class FrameworkSync {
     let synced = 0;
 
     if (targetDirs.commands) {
-      const commandNames = FrameworkSync.COMMAND_NAMES;
+      const commandNames = COMMAND_AGENT_NAMES;
 
       if (hasBackendCommands) {
         // Prefer backend-specific command files, fall back to generic agents
         synced += this.syncDir(commandsSrcDir, targetDirs.commands);
         // Also sync any command agents that don't have a backend-specific version
-        const backendCommandFiles = new Set(
-          fs.readdirSync(commandsSrcDir).filter((f) => f.endsWith('.md')).map((f) => f.replace('.md', '')),
-        );
-        synced += this.syncDir(agentsSrcDir, targetDirs.commands, (f) =>
-          commandNames.has(f.replace('.md', '')) && !backendCommandFiles.has(f.replace('.md', '')),
-        );
+        let backendCommandFiles: Set<string>;
+        try {
+          backendCommandFiles = new Set(
+            fs.readdirSync(commandsSrcDir).filter((f) => f.endsWith('.md')).map((f) => f.replace('.md', '')),
+          );
+        } catch {
+          backendCommandFiles = new Set();
+        }
+        const fallbackFilter = (f: string) => {
+          const name = f.replace('.md', '');
+          return commandNames.has(name) && !backendCommandFiles.has(name);
+        };
+        const fallbackCount = this.syncDir(agentsSrcDir, targetDirs.commands, fallbackFilter);
+        // Warn about command agents with no source file in either location
+        for (const name of commandNames) {
+          if (!backendCommandFiles.has(name) && !fs.existsSync(path.join(agentsSrcDir, `${name}.md`))) {
+            console.warn(`DevSquire: command agent '${name}' has no source file in commands or agents directory`);
+          }
+        }
+        synced += fallbackCount;
       } else {
         // No backend-specific commands — use generic agent files as commands
         synced += this.syncDir(agentsSrcDir, targetDirs.commands, (f) => commandNames.has(f.replace('.md', '')));


### PR DESCRIPTION
## Summary

- Add `framework/commands/claude/` directory with Claude Code-specific command files that use native orchestration primitives
- **squire-dev-issue**: Uses `EnterWorktree`, `TeamCreate`, `TaskCreate`, `Agent(team_name=...)`, `SendMessage`, `TeamDelete` for true parallel agent coordination
- **squire-watch-pr**: Uses `CronCreate` for 10-minute polling instead of shell sleep loops (auto-expires after 7 days)
- Update `framework-sync.ts` to prefer backend-specific commands from `framework/commands/<backend-type>/` over generic `framework/agents/` versions, with fallback
- All JSONL dashboard logging (`.squire/logs/`, `.squire/pending-decisions/`) preserved — no dashboard impact

## Test plan

- [ ] `npm run compile` passes
- [ ] Verify Claude backend syncs commands from `framework/commands/claude/` to `~/.claude/commands/`
- [ ] Verify Copilot backend still syncs from `framework/agents/` (no regression)
- [ ] Verify `squire-pr-reviewer` (no Claude-specific version) falls back to generic agent file