### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in DevSquire, please report it responsibly. **Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. **GitHub Security Advisories (preferred):** Go to the [Security Advisories](https://github.com/frankliu20/DevSquire/security/advisories/new) page and create a new advisory. This ensures the report is private and trackable.
+
+2. **Email:** Send details to the repository maintainer via the email listed on their [GitHub profile](https://github.com/frankliu20).
+
+### What to Include
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Any suggested fix (optional)
+
+## Response Timeline
+
+| Step                  | Timeframe       |
+| --------------------- | --------------- |
+| Acknowledgment        | Within 48 hours |
+| Initial assessment    | Within 7 days   |
+| Fix or mitigation     | Within 30 days  |
+| Public disclosure     | After fix is released |
+
+## Disclosure Policy
+
+- We follow [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
+- We will credit reporters in the release notes (unless anonymity is requested).
+- We ask that you give us reasonable time to address the issue before any public disclosure.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with supported versions, vulnerability reporting instructions (GitHub Security Advisories + email), response timeline, and disclosure policy

Closes https://github.com/frankliu20/DevSquire/issues/39

## Test plan
- [x] Verify SECURITY.md renders correctly on GitHub
- [x] Verify links to Security Advisories page and maintainer profile work