### PR TITLE
feat(logging): cross-platform sq.mjs helper for reliable task logging

### DIFF
--- a/framework/agents/squire-dev-issue.md
+++ b/framework/agents/squire-dev-issue.md
@@ -24,123 +24,94 @@ When `--test-scenario` is provided in **auto mode**: ignored — auto mode alway
 
 Strip `--auto` and `--test-scenario <id>` from the input before processing the issue URL/description.
 
-## Task Log ID
+## Task Log ID & Squire Directory
 
-Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+Parse these two tags from the prompt input. **Strip them before processing the issue URL/description.**
 
-Use this ID for **ALL** logging:
-- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
-- `task_id` field in all log entries: `<ID>`
-- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
+- `[task-log-id:<ID>]` → `TASK_LOG_ID` (e.g., `task-issue-123`)
+- `[squire-dir:<PATH>]` → `SQUIRE_DIR` (absolute path to `.squire/`, e.g., `C:/Users/me/project/.squire`)
 
 If `[task-log-id:...]` is not provided, derive the ID:
 - Issue URL with number → `task-issue-<N>`
 - Plain text / adhoc → `task-adhoc-<date>`
 
-Example: `[task-log-id:task-issue-123] --auto https://github.com/org/repo/issues/123`
-→ `TASK_LOG_ID=task-issue-123`, mode=auto, issue URL = `https://github.com/org/repo/issues/123`
+If `[squire-dir:...]` is not provided, fall back to: `$(git rev-parse --show-toplevel)/.squire`
+
+The `sq.mjs` helper script at `$SQUIRE_DIR/bin/sq.mjs` handles all logging and decisions. **Never construct JSON manually. Never use echo to write JSONL. Always use `sq.mjs`.**
+
+Example: `[task-log-id:task-issue-123] [squire-dir:C:/Users/me/project/.squire] --auto https://github.com/org/repo/issues/123`
+→ `TASK_LOG_ID=task-issue-123`, `SQUIRE_DIR=C:/Users/me/project/.squire`, mode=auto
 
 ## Workspace
 
-Detect the repo slug and **repo root** from git remote:
+Detect the repo slug from git remote:
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
 
 All operations use `gh` CLI (GitHub only).
 - The current directory is the workspace root (or worktree).
-- **CRITICAL: Logs and decisions are ALWAYS written to `$REPO_ROOT/.squire/`** — the repo root, NOT the current working directory. After `cd` into a worktree, relative paths like `.squire/logs/` resolve inside the worktree, which is WRONG. Always use `"$REPO_ROOT/.squire/logs/"` and `"$REPO_ROOT/.squire/pending-decisions/"` for all log and decision file paths.
-- Worktrees are created under `$REPO_ROOT/.squire/worktrees/`.
+- Worktrees are created under `$SQUIRE_DIR/worktrees/`.
 - **Always `cd` into the correct worktree directory before running any git/build/test commands.**
-
-**Status log**: Throughout every phase, write status updates to per-task log files under `$REPO_ROOT/.squire/logs/` (one file per task, e.g., `task-issue-123.jsonl`). Use the `$TASK_LOG_ID` parsed above. These logs are the single source of truth for all task/PR progress.
 
 ## Status Logging — MANDATORY
 
-**You MUST run an echo command at every phase transition listed below. This is not optional. The dashboard depends on these logs to show progress. If you skip logging, the user sees a stuck task.**
+**You MUST log at every phase transition. The dashboard depends on these logs. If you skip logging, the user sees a stuck task.**
 
-Log file: `$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl` — replace `$TASK_LOG_ID` with the actual value parsed from `[task-log-id:...]`.
+Use the `sq.mjs` helper — it handles timestamps, JSON format, and writes to the correct path regardless of your current directory:
 
-**Run the first log IMMEDIATELY when you start, before any other work:**
 ```bash
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"task_start\",\"phase\":\"analyzing\",\"branch\":\"$BRANCH\",\"detail\":\"Starting issue analysis\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
-```
+# Shorthand: SQ="node $SQUIRE_DIR/bin/sq.mjs"
+# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
 
-Then log at each subsequent transition:
-```bash
+# Run IMMEDIATELY when you start, before any other work:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH"
+
 # Phase 1 done — issue understood:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"analysis_done\",\"phase\":\"exploring\",\"branch\":\"$BRANCH\",\"detail\":\"Issue analyzed\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH"
 
 # Phase 2 done — code explored:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"exploration_done\",\"phase\":\"planning\",\"branch\":\"$BRANCH\",\"detail\":\"Code explored\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH"
 
 # Phase 3 done — plan approved:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"plan_approved\",\"phase\":\"implementing\",\"branch\":\"$BRANCH\",\"detail\":\"Plan approved\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH"
 
 # Phase 4 done — code written:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"implementation_done\",\"phase\":\"testing\",\"branch\":\"$BRANCH\",\"detail\":\"Implementation complete\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH"
 
 # Phase 5 — tests passed:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"test_pass\",\"phase\":\"creating_pr\",\"branch\":\"$BRANCH\",\"detail\":\"Tests passed\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH"
 
 # Phase 5 — tests failed:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"test_fail\",\"phase\":\"testing\",\"branch\":\"$BRANCH\",\"detail\":\"<error summary>\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH"
 
 # Phase 6 — PR created:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"pr_created\",\"phase\":\"done\",\"branch\":\"$BRANCH\",\"pr_number\":$PR_NUM,\"detail\":\"PR created\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM
 
 # Blocked:
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"blocked\",\"phase\":\"failed\",\"branch\":\"$BRANCH\",\"detail\":\"<reason>\"}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH"
 ```
 
-Replace `$TASK_LOG_ID`, `$BRANCH`, `$PR_NUM` with actual values. **Do not skip any of these logs.**
+Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM` with actual values. **Do not skip any of these logs.**
 
 ## Decision Notifications
 
-**CRITICAL RULE**: Every single time you stop and wait for user input — for ANY reason, in ANY phase — you MUST write a decision notification file BEFORE prompting the user. The user may not be watching your terminal. The Dashboard will pop up a notification so they know you need attention.
+**CRITICAL RULE**: Every time you stop and wait for user input — for ANY reason — you MUST create a decision notification BEFORE prompting the user. The Dashboard will pop up a notification so the user knows you need attention.
 
-This applies to ALL situations where you ask the user a question or present options, including but not limited to:
-- Plan approval / test strategy selection
-- Suggesting to close an issue instead of coding
-- Asking for clarification on unclear requirements
-- Manual verification confirmation
-- Reporting test failures after 3 rounds
-- Proposing a fix approach when multiple options exist
-- **Any other prompt that waits for user response**
-
-If you are about to use `AskUserQuestion`, present options, or end your turn with a question — you MUST write the file first.
+This applies to: plan approval, clarification questions, test failures, manual verify, etc.
 
 ### How it works
 
-1. **Write a decision request file** to `$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json`:
+1. **Create the decision** (one command — writes both the notification file AND the JSONL log entry):
 ```bash
-mkdir -p "$REPO_ROOT/.squire/pending-decisions"
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'DECISION'
-{
-  "id": "$TASK_LOG_ID-<timestamp>",
-  "taskId": "$TASK_LOG_ID",
-  "type": "decision",
-  "title": "<short title, e.g. Plan Approval for Issue #N>",
-  "message": "<what you need from the user>",
-  "options": ["option1", "option2", "option3"],
-  "prNumber": null,
-  "prUrl": null,
-  "createdAt": "<ISO8601>"
-}
-DECISION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes"
 ```
 
-2. **Also log a status event** with type `decision_requested`:
-```bash
-echo '{"timestamp":"<ISO8601>","task_id":"$TASK_LOG_ID","type":"decision_requested","phase":"<phase>","branch":"<branch>","pr_number":null,"status":"waiting","detail":"<question summary>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
-```
+2. **Then wait for user input** in the terminal as normal.
 
-3. **Then wait for user input in the terminal as normal** (the user will see the Dashboard notification and switch to your terminal to respond).
-
-4. **After user responds**, delete the pending decision file:
+3. **After user responds**, clear the decision:
 ```bash
-rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"
+node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"
 ```
 
 **Auto mode exception**: Never write decision requests — use defaults silently.
@@ -156,19 +127,7 @@ The user provides ONE of:
 
 **Before creating anything, check if there's already work in progress for this issue.**
 
-Each issue gets its own **git worktree** at `.squire/worktrees/issue-<N>/`, enabling parallel development across multiple issues.
-
-### Determine base repo path
-
-Extract the repo name from the issue URL (e.g., `my-project` from `https://github.com/org/my-project/issues/123`). 
-
-```bash
-# Repo is current directory
-```
-
-If the input is plain text (no URL), use the current directory:
-```bash
-```
+Each issue gets its own **git worktree** at `$SQUIRE_DIR/worktrees/issue-<N>/`, enabling parallel development across multiple issues.
 
 ### Step 1: Check for existing worktrees, branches, and PRs (run in parallel)
 ```bash
@@ -201,8 +160,8 @@ gh pr list --repo $REPO_SLUG \
   ```bash
   # already in repo
   git fetch origin
-  git worktree add ".squire/worktrees/issue-<N>" origin/<branch>
-  cd ".squire/worktrees/issue-<N>"
+  git worktree add "$SQUIRE_DIR/worktrees/issue-<N>" origin/<branch>
+  cd "$SQUIRE_DIR/worktrees/issue-<N>"
   ```
 
 **If an existing branch is found (no worktree, no PR):**
@@ -215,8 +174,8 @@ gh pr list --repo $REPO_SLUG \
 ```bash
 # already in repo
 git fetch origin
-git worktree add -b fix/issue-<number> ".squire/worktrees/issue-<number>" origin/main
-cd ".squire/worktrees/issue-<number>"
+git worktree add -b fix/issue-<number> "$SQUIRE_DIR/worktrees/issue-<number>" origin/main
+cd "$SQUIRE_DIR/worktrees/issue-<number>"
 ```
 Branch name: `fix/issue-<number>` (bug fix) or `feat/issue-<number>` (feature)
 
@@ -225,8 +184,8 @@ Branch name: `fix/issue-<number>` (bug fix) or `feat/issue-<number>` (feature)
 # already in repo
 git fetch origin
 TASK_ID="adhoc-$(date +%Y%m%d-%H%M%S)"
-git worktree add -b fix/$TASK_ID ".squire/worktrees/$TASK_ID" origin/main
-cd ".squire/worktrees/$TASK_ID"
+git worktree add -b fix/$TASK_ID "$SQUIRE_DIR/worktrees/$TASK_ID" origin/main
+cd "$SQUIRE_DIR/worktrees/$TASK_ID"
 ```
 Branch name: `fix/adhoc-20260405-143022` or `feat/adhoc-20260405-143022`
 
@@ -320,7 +279,11 @@ Approve the plan to proceed? (y/n)
 ```
 After approval, proceed to Phase 4 with the pre-selected strategy. The user can override by typing a different strategy number.
 
-**Otherwise (no `--test-scenario`)**, write a decision notification file (see "Decision Notifications" section above) so the Dashboard can alert the user that this task needs attention, then prompt:
+**Otherwise (no `--test-scenario`)**, create a decision notification so the Dashboard can alert the user:
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes"
+```
+Then prompt:
 
 ```
 Plan is ready. How should we verify the changes?
@@ -334,7 +297,10 @@ Pick 1/2/3 (default: 1):
 
 **Wait for user to approve the plan AND choose a test strategy before proceeding.**
 If the user just approves without picking, use strategy 1 (build only).
-After user responds, delete the pending decision file.
+After user responds, clear the decision:
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"
+```
 
 ## Phase 4: Implementation
 
@@ -378,9 +344,9 @@ If the file does not exist or a field is missing, auto-detect from project files
 - Run build + impacted tests (same as strategy 2)
 - If either fails: auto-fix up to 3 rounds
 - All pass → prepare the manual verify environment and STOP:
-  - **Before prompting the user**, write a decision notification file (see "Decision Notifications" section).
+  - Create a decision: `node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues"`
   - Wait for user to reply "ok" or describe issues to fix.
-  - After user responds, delete the pending decision file.
+  - After user responds: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
 
 If auto-fix fails after 3 rounds on any strategy:
 - STOP and report to the user with error details.

--- a/framework/agents/squire-pr-reviewer.md
+++ b/framework/agents/squire-pr-reviewer.md
@@ -10,25 +10,25 @@ You are a code review agentic engineer of DevSquire. The user gives you a PR URL
 - The PR URL in the prompt tells you which repo to review. Extract the owner/repo from the URL.
 - Do NOT hardcode a repo — always derive it from the PR URL.
 
-## Task Log ID
+## Task Log ID & Squire Directory
 
-Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+Parse these two tags from the prompt input. **Strip them before processing the PR URL.**
 
-Use this ID for **ALL** logging:
-- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
-- `task_id` field in all log entries: `<ID>`
+- `[task-log-id:<ID>]` → `TASK_LOG_ID` (e.g., `task-review-66`)
+- `[squire-dir:<PATH>]` → `SQUIRE_DIR` (absolute path to `.squire/`, e.g., `C:/Users/me/project/.squire`)
 
 If `[task-log-id:...]` is not provided, derive: `task-review-<N>` from the PR number.
+
+If `[squire-dir:...]` is not provided, fall back to: `$(git rev-parse --show-toplevel)/.squire`
+
+The `sq.mjs` helper script at `$SQUIRE_DIR/bin/sq.mjs` handles all logging and decisions. **Never construct JSON manually. Never use echo to write JSONL. Always use `sq.mjs`.**
 
 ## Workspace
 
 GitHub only. Use `gh` CLI for all PR operations. Extract repo from the PR URL.
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
-
-**CRITICAL: All log paths MUST use `$REPO_ROOT/.squire/`** — not relative `.squire/`. After `cd` into a worktree, relative paths resolve inside the worktree, making logs invisible to the Dashboard.
 
 ## Review Configuration
 
@@ -169,7 +169,7 @@ For each unresolved comment:
 
 **After presenting the review summary, log completion:**
 ```bash
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"review_done\",\"phase\":\"done\",\"pr_number\":$PR_NUMBER}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
 ```
 
 Follow the strategy-specific behavior defined above. For `normal`, wait for user input. For `auto` and `quick-approve`, proceed immediately.
@@ -272,12 +272,12 @@ The extension writes `reviewing` on task start. You handle the rest:
 
 **After presenting the review summary** (all strategies, including own-PR):
 ```bash
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"review_done\",\"phase\":\"done\",\"pr_number\":$PR_NUMBER}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
 ```
 
 **After publishing a review to GitHub** (auto/quick-approve strategy, NOT own-PR):
 ```bash
-echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"task_id\":\"$TASK_LOG_ID\",\"type\":\"review_published\",\"phase\":\"published\",\"pr_number\":$PR_NUMBER}" >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_published "Review published" --pr $PR_NUMBER
 ```
 
-Replace `$TASK_LOG_ID` and `$PR_NUMBER` with actual values.
+Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, and `$PR_NUMBER` with actual values.

--- a/framework/agents/squire-watch-pr.md
+++ b/framework/agents/squire-watch-pr.md
@@ -10,16 +10,18 @@ You are a PR monitoring agentic engineer of DevSquire with auto-fix capabilities
 - **Repo**: Detect from git remote: `REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')`. Monitor PRs for this repo.
 - **Scope**: Only my own PRs (`--author @me`).
 
-## Task Log ID
+## Task Log ID & Squire Directory
 
-Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+Parse these two tags from the prompt input. **Strip them before processing.**
 
-Use this ID for **ALL** logging:
-- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
-- `task_id` field in all log entries: `<ID>`
-- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
+- `[task-log-id:<ID>]` → `TASK_LOG_ID` (e.g., `task-watch`)
+- `[squire-dir:<PATH>]` → `SQUIRE_DIR` (absolute path to `.squire/`, e.g., `C:/Users/me/project/.squire`)
 
 If `[task-log-id:...]` is not provided, use `task-watch`.
+
+If `[squire-dir:...]` is not provided, fall back to: `$(git rev-parse --show-toplevel)/.squire`
+
+The `sq.mjs` helper script at `$SQUIRE_DIR/bin/sq.mjs` handles all logging and decisions. **Never construct JSON manually. Never use echo to write JSONL. Always use `sq.mjs`.**
 
 ## Configuration
 
@@ -34,10 +36,7 @@ Defaults if not provided: auto-fix CI = on, auto-fix comments = off.
 The current directory is the workspace root. All operations use `gh` CLI (GitHub only).
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
-
-**CRITICAL: All log and decision paths MUST use `$REPO_ROOT/.squire/`** — not relative `.squire/`. After `cd` into a worktree, relative paths resolve inside the worktree, making logs invisible to the Dashboard.
 
 All operations use `gh` CLI (GitHub only). GraphQL review threads are fully supported.
 
@@ -131,7 +130,7 @@ After detecting and reporting, attempt auto-fix for enabled conditions.
 
 #### Auto-Fix State Tracking
 
-Maintain a counter per PR per fix type. Persist in `$REPO_ROOT/.squire/logs/auto-fix-state.json`:
+Maintain a counter per PR per fix type. Persist in `$SQUIRE_DIR/logs/auto-fix-state.json`:
 ```json
 {
   "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
@@ -177,63 +176,26 @@ Only trigger when **new** unresolved comments appear (count increased since last
 
 ## Dashboard Notifications
 
-When a condition is detected and it's NEW (changed since last cycle), write a notification file:
-
-```bash
-mkdir -p "$REPO_ROOT/.squire/pending-decisions"
-```
+When a condition is detected and it's NEW (changed since last cycle), write a notification using `sq.mjs`:
 
 ### For CI failure:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> CI failed: <failure summary>",
-  "options": ["Auto-fixing...", "Review Logs", "Dismiss"],
-  "context": "<failed job names and brief error>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> CI failed: <failure summary>" "Auto-fixing...,Review Logs,Dismiss"
 ```
 
 ### For unresolved comments:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> has <count> unresolved review comments",
-  "options": ["Fix Comments", "Review", "Dismiss"],
-  "context": "<reviewer names and first line of each unresolved comment>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> has <count> unresolved review comments" "Fix Comments,Review,Dismiss"
 ```
 
 ### For ready to merge:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << 'NOTIFICATION'
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> is approved and CI green — ready to merge!",
-  "options": ["Merge", "Review", "Dismiss"],
-  "context": "<PR title, approver names>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> is approved and CI green — ready to merge!" "Merge,Review,Dismiss"
 ```
 
 ### Cleanup notifications:
 - If a PR gets merged or closed → **auto-cleanup**:
-  1. Delete its notification: `rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"`
+  1. Clear notification: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
   2. Remove auto-fix state for this PR from `auto-fix-state.json`
   3. Find and remove the worktree for this PR's branch:
      ```bash
@@ -244,16 +206,16 @@ NOTIFICATION
        git branch -D "<branch>"
      fi
      ```
-  4. Log `pr_merged` event
+  4. Log `pr_merged` event: `node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_merged "PR merged" --pr $PR_NUMBER`
 - CI goes green → reset `ci_attempts` to 0 for that PR
-- If unresolved comments drop to 0 → delete the notification, reset `comment_attempts`
+- If unresolved comments drop to 0 → clear the notification, reset `comment_attempts`
 - If the same PR already has a notification → overwrite with latest state
 
 ## Status Logging
 
-After every action, append a JSON line to the task's log file:
+After every action, log using `sq.mjs`:
 ```bash
-echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"$TASK_LOG_ID","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> "<detail>" --pr $PR_NUMBER
 ```
 
 Event types and phases:

--- a/framework/commands/claude/squire-dev-issue.md
+++ b/framework/commands/claude/squire-dev-issue.md
@@ -20,95 +20,86 @@ Also check for `--test-scenario <id>` where `<id>` matches a scenario defined by
 
 Strip `--auto` and `--test-scenario <id>` from input before processing.
 
-## Task Log ID
+## Task Log ID & Squire Directory
 
-Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+Parse these two tags from the prompt input. **Strip them before processing the issue URL/description.**
 
-Use this ID for **ALL** logging:
-- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
-- `task_id` field in all log entries: `<ID>`
-- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
+- `[task-log-id:<ID>]` → `TASK_LOG_ID` (e.g., `task-issue-123`)
+- `[squire-dir:<PATH>]` → `SQUIRE_DIR` (absolute path to `.squire/`, e.g., `C:/Users/me/project/.squire`)
 
 If `[task-log-id:...]` is not provided, derive the ID:
 - Issue URL with number → `task-issue-<N>`
 - Plain text / adhoc → `task-adhoc-<date>`
 
+If `[squire-dir:...]` is not provided, fall back to: `$(git rev-parse --show-toplevel)/.squire`
+
+The `sq.mjs` helper script at `$SQUIRE_DIR/bin/sq.mjs` handles all logging and decisions. **Never construct JSON manually. Never use echo to write JSONL. Always use `sq.mjs`.**
+
 ## Workspace
 
-Detect the repo slug and **repo root** from git remote:
+Detect the repo slug from git remote:
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
 
 All operations use `gh` CLI (GitHub only).
 - The current directory is the workspace root (or worktree).
-- **CRITICAL: Logs and decisions are ALWAYS written to `$REPO_ROOT/.squire/`** — the repo root, NOT the current working directory. After `EnterWorktree`, relative paths like `.squire/logs/` resolve inside the worktree, which is WRONG. Always use `"$REPO_ROOT/.squire/logs/"` and `"$REPO_ROOT/.squire/pending-decisions/"` for all log and decision file paths.
 - **Always `cd` into the correct worktree directory before running any git/build/test commands.**
 
 ## Status Logging — MANDATORY
 
-**You MUST run an echo command at every phase transition listed below. This is not optional. The dashboard depends on these logs to show progress.**
+**You MUST log at every phase transition. The dashboard depends on these logs. If you skip logging, the user sees a stuck task.**
 
-Log file: `$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl`
+Use the `sq.mjs` helper — it handles timestamps, JSON format, and writes to the correct path regardless of your current directory:
 
-**Run the first log IMMEDIATELY when you start, before any other work:**
 ```bash
-echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"task_start","phase":"analyzing","branch":"'"$BRANCH"'","detail":"Starting issue analysis"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
-```
+# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
 
-Then log at each subsequent transition:
-```bash
-# Phase 1 done:
-echo '{"timestamp":"...","task_id":"...","type":"analysis_done","phase":"exploring","branch":"...","detail":"Issue analyzed"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# Run IMMEDIATELY when you start, before any other work:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH"
 
-# Phase 2 done:
-echo '{"timestamp":"...","task_id":"...","type":"exploration_done","phase":"planning","branch":"...","detail":"Code explored"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# After issue analysis:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH"
 
-# Phase 3 done:
-echo '{"timestamp":"...","task_id":"...","type":"plan_approved","phase":"implementing","branch":"...","detail":"Plan approved"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# After code exploration:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH"
 
-# Phase 4 done:
-echo '{"timestamp":"...","task_id":"...","type":"implementation_done","phase":"testing","branch":"...","detail":"Implementation complete"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# After plan approved:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH"
 
-# Phase 5 — tests passed:
-echo '{"timestamp":"...","task_id":"...","type":"test_pass","phase":"creating_pr","branch":"...","detail":"Tests passed"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# After implementation:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH"
 
-# Phase 5 — tests failed:
-echo '{"timestamp":"...","task_id":"...","type":"test_fail","phase":"testing","branch":"...","detail":"<error summary>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# Tests passed:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH"
 
-# Phase 6 — PR created:
-echo '{"timestamp":"...","task_id":"...","type":"pr_created","phase":"done","branch":"...","pr_number":N,"detail":"PR created"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+# Tests failed:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH"
+
+# PR created:
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM
 
 # Blocked:
-echo '{"timestamp":"...","task_id":"...","type":"blocked","phase":"failed","branch":"...","detail":"<reason>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH"
 ```
 
-Replace all `...` with actual values. **Do not skip any of these logs.**
+Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM` with actual values. **Do not skip any of these logs.**
 
 ## Decision Notifications
 
-**CRITICAL RULE**: Every time you stop and wait for user input — for ANY reason — you MUST write a decision notification file BEFORE prompting the user. The Dashboard will pop up a notification.
+**CRITICAL RULE**: Every time you stop and wait for user input — for ANY reason — you MUST create a decision notification BEFORE prompting the user. The Dashboard will pop up a notification.
 
-1. **Write a decision request file** to `$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json`:
+1. **Create the decision** (one command — writes both the notification file AND the JSONL log entry):
 ```bash
-mkdir -p "$REPO_ROOT/.squire/pending-decisions"
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << DECISION
-{
-  "id": "$TASK_LOG_ID-$(date +%s)",
-  "taskId": "$TASK_LOG_ID",
-  "type": "decision",
-  "title": "<short title>",
-  "message": "<what you need from the user>",
-  "options": ["option1", "option2"],
-  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-DECISION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes"
 ```
 
-2. **Also log** a `decision_requested` event to the JSONL file.
+2. **Then wait for user input** in the terminal as normal.
 
-3. **After user responds**, delete: `rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"`
+3. **After user responds**, clear the decision:
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"
+```
 
 **Auto mode exception**: Never write decision requests — use defaults silently.
 
@@ -231,7 +222,11 @@ Based on exploration, create a plan:
 
 **If `--test-scenario` provided**: Present plan, skip test strategy prompt, inform user of pre-selected strategy.
 
-**Otherwise**, write a decision notification file, then prompt:
+**Otherwise**, create a decision notification, then prompt:
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes"
+```
+Then show:
 ```
 Plan is ready. How should we verify the changes?
 
@@ -242,7 +237,10 @@ Plan is ready. How should we verify the changes?
 Pick 1/2/3 (default: 1):
 ```
 
-Wait for approval. If user just approves without picking, use strategy 1.
+Wait for approval. If user just approves without picking, use strategy 1. After user responds:
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"
+```
 
 ## Step 6: Implementation
 
@@ -279,7 +277,10 @@ If not found, auto-detect from project files (`package.json`, `pom.xml`, `Makefi
 ### Strategy 3 — Build + Tests + Manual Verify:
 - Run build + impacted tests (same as strategy 2)
 - Failures → auto-fix up to 3 rounds
-- All pass → write decision notification, wait for user "ok"
+- All pass → create decision notification and wait for user "ok":
+  ```bash
+  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues"
+  ```
 
 **If auto-fix fails after 3 rounds**: STOP and report. **Auto mode**: log `blocked` and stop.
 

--- a/framework/commands/claude/squire-watch-pr.md
+++ b/framework/commands/claude/squire-watch-pr.md
@@ -10,16 +10,18 @@ You are a DevSquire PR monitoring daemon with auto-fix capabilities. **Automatic
 - **Repo**: Detect from git remote: `REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')`. Monitor PRs for this repo.
 - **Scope**: Only my own PRs (`--author @me`).
 
-## Task Log ID
+## Task Log ID & Squire Directory
 
-Parse `[task-log-id:<ID>]` from the prompt if present. Strip it from the input before processing.
+Parse these two tags from the prompt input. **Strip them before processing.**
 
-Use this ID for **ALL** logging:
-- JSONL file: `$REPO_ROOT/.squire/logs/<ID>.jsonl`
-- `task_id` field in all log entries: `<ID>`
-- Decision files: `$REPO_ROOT/.squire/pending-decisions/<ID>.json`
+- `[task-log-id:<ID>]` → `TASK_LOG_ID` (e.g., `task-watch`)
+- `[squire-dir:<PATH>]` → `SQUIRE_DIR` (absolute path to `.squire/`, e.g., `C:/Users/me/project/.squire`)
 
 If `[task-log-id:...]` is not provided, use `task-watch`.
+
+If `[squire-dir:...]` is not provided, fall back to: `$(git rev-parse --show-toplevel)/.squire`
+
+The `sq.mjs` helper script at `$SQUIRE_DIR/bin/sq.mjs` handles all logging and decisions. **Never construct JSON manually. Never use echo to write JSONL. Always use `sq.mjs`.**
 
 ## Configuration
 
@@ -34,10 +36,7 @@ Defaults if not provided: auto-fix CI = on, auto-fix comments = off.
 The current directory is the workspace root. All operations use `gh` CLI (GitHub only).
 ```bash
 REPO_SLUG=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-REPO_ROOT=$(git rev-parse --show-toplevel)
 ```
-
-**CRITICAL: All log and decision paths MUST use `$REPO_ROOT/.squire/`** — not relative `.squire/`. After `cd` into a worktree, relative paths resolve inside the worktree, making logs invisible to the Dashboard.
 
 ## On Launch: Set Up Monitoring
 
@@ -131,7 +130,7 @@ PR Monitor — <time> — no open PRs
 
 #### Auto-Fix State Tracking
 
-Maintain a counter per PR per fix type. Persist in `$REPO_ROOT/.squire/logs/auto-fix-state.json`:
+Maintain a counter per PR per fix type. Persist in `$SQUIRE_DIR/logs/auto-fix-state.json`:
 ```json
 {
   "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
@@ -169,75 +168,38 @@ Only trigger when **new** unresolved comments appear (count increased since last
 
 ## Dashboard Notifications
 
-When a condition is detected and it's NEW (changed since last cycle), write a notification file:
-
-```bash
-mkdir -p "$REPO_ROOT/.squire/pending-decisions"
-```
+When a condition is detected and it's NEW (changed since last cycle), write a notification using `sq.mjs`:
 
 ### For CI failure:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> CI failed: <failure summary>",
-  "options": ["Auto-fixing...", "Review Logs", "Dismiss"],
-  "context": "<failed job names and brief error>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> CI failed: <failure summary>" "Auto-fixing...,Review Logs,Dismiss"
 ```
 
 ### For unresolved comments:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> has <count> unresolved review comments",
-  "options": ["Fix Comments", "Review", "Dismiss"],
-  "context": "<reviewer names and first line of each unresolved comment>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> has <count> unresolved review comments" "Fix Comments,Review,Dismiss"
 ```
 
 ### For ready to merge:
 ```bash
-cat > "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json" << NOTIFICATION
-{
-  "taskId": "$TASK_LOG_ID",
-  "issueNumber": null,
-  "prNumber": <N>,
-  "phase": "pr_notification",
-  "question": "PR #<N> is approved and CI green — ready to merge!",
-  "options": ["Merge", "Review", "Dismiss"],
-  "context": "<PR title, approver names>",
-  "timestamp": "<ISO8601>"
-}
-NOTIFICATION
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "PR #<N> is approved and CI green — ready to merge!" "Merge,Review,Dismiss"
 ```
 
 ### Cleanup notifications:
 - PR merged/closed → **auto-cleanup**:
-  1. Delete its notification: `rm -f "$REPO_ROOT/.squire/pending-decisions/$TASK_LOG_ID.json"`
+  1. Clear notification: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
   2. Remove auto-fix state for this PR from `auto-fix-state.json`
   3. Find and remove the worktree for this PR's branch
-  4. Log `pr_merged` event
+  4. Log `pr_merged` event: `node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_merged "PR merged" --pr $PR_NUMBER`
 - CI goes green → reset `ci_attempts` to 0
-- Unresolved comments drop to 0 → delete notification, reset `comment_attempts`
+- Unresolved comments drop to 0 → clear notification, reset `comment_attempts`
 - Same PR already has notification → overwrite with latest state
 
 ## Status Logging
 
-After every action, append a JSON line to the task's log file:
+After every action, log using `sq.mjs`:
 ```bash
-echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","task_id":"'"$TASK_LOG_ID"'","type":"<event>","phase":"<phase>","pr_number":<N>,"detail":"<message>"}' >> "$REPO_ROOT/.squire/logs/$TASK_LOG_ID.jsonl"
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> "<detail>" --pr $PR_NUMBER
 ```
 
 Event types and phases:

--- a/src/sq-script.ts
+++ b/src/sq-script.ts
@@ -1,0 +1,106 @@
+/**
+ * Embedded source for the `.squire/bin/sq.mjs` helper script.
+ *
+ * This Node.js script is written to disk by SquireDir.ensureBinScript()
+ * and invoked by LLM agents to log events and manage decisions.
+ * Using Node.js ensures cross-platform compatibility (Windows/macOS/Linux).
+ *
+ * Usage (from agent prompts):
+ *   node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" <task-id> <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
+ *   node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" <task-id> <title> <options-csv>
+ *   node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" <task-id>
+ */
+export const SQ_SCRIPT = `#!/usr/bin/env node
+import { writeFileSync, appendFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+const [,, cmd, squireDir, ...rest] = process.argv;
+
+if (!cmd || !squireDir) {
+  console.error('Usage: sq.mjs <log|decision|decision-clear> <squire-dir> ...');
+  process.exit(1);
+}
+
+const logsDir = join(squireDir, 'logs');
+const decisionsDir = join(squireDir, 'pending-decisions');
+const ts = new Date().toISOString().replace(/\\.\\d{3}Z$/, 'Z');
+
+function parseFlags(args) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--') && i + 1 < args.length) {
+      flags[args[i].slice(2)] = args[++i];
+    } else {
+      positional.push(args[i]);
+    }
+  }
+  return { positional, flags };
+}
+
+if (cmd === 'log') {
+  // sq.mjs log <squire-dir> <task-id> <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
+  const { positional, flags } = parseFlags(rest);
+  const [taskId, eventType, detail] = positional;
+  if (!taskId || !eventType) {
+    console.error('Usage: sq.mjs log <squire-dir> <task-id> <event-type> <detail> [--branch X] [--pr N]');
+    process.exit(1);
+  }
+  const entry = {
+    timestamp: ts,
+    task_id: taskId,
+    type: eventType,
+    detail: detail || '',
+  };
+  if (flags.branch) entry.branch = flags.branch;
+  if (flags.pr) entry.pr_number = parseInt(flags.pr, 10);
+  if (flags['pr-url']) entry.pr_url = flags['pr-url'];
+
+  mkdirSync(logsDir, { recursive: true });
+  appendFileSync(join(logsDir, taskId + '.jsonl'), JSON.stringify(entry) + String.fromCharCode(10));
+
+} else if (cmd === 'decision') {
+  // sq.mjs decision <squire-dir> <task-id> <title> <options-csv>
+  const [taskId, title, optionsCsv] = rest;
+  if (!taskId || !title) {
+    console.error('Usage: sq.mjs decision <squire-dir> <task-id> <title> <options-csv>');
+    process.exit(1);
+  }
+  const options = optionsCsv ? optionsCsv.split(',').map(s => s.trim()) : [];
+  const id = taskId + '-' + Date.now();
+  const decision = {
+    id,
+    taskId,
+    type: 'decision',
+    title,
+    message: title,
+    options,
+    createdAt: ts,
+  };
+  mkdirSync(decisionsDir, { recursive: true });
+  writeFileSync(join(decisionsDir, taskId + '.json'), JSON.stringify(decision, null, 2));
+
+  // Also log the decision_requested event
+  const logEntry = {
+    timestamp: ts,
+    task_id: taskId,
+    type: 'decision_requested',
+    detail: title,
+  };
+  mkdirSync(logsDir, { recursive: true });
+  appendFileSync(join(logsDir, taskId + '.jsonl'), JSON.stringify(logEntry) + String.fromCharCode(10));
+
+} else if (cmd === 'decision-clear') {
+  // sq.mjs decision-clear <squire-dir> <task-id>
+  const [taskId] = rest;
+  if (!taskId) {
+    console.error('Usage: sq.mjs decision-clear <squire-dir> <task-id>');
+    process.exit(1);
+  }
+  try { unlinkSync(join(decisionsDir, taskId + '.json')); } catch { /* ok if missing */ }
+
+} else {
+  console.error('Unknown command: ' + cmd + '. Use: log, decision, decision-clear');
+  process.exit(1);
+}
+`;

--- a/src/squire-dir.ts
+++ b/src/squire-dir.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { SQ_SCRIPT } from './sq-script';
 
 /**
  * Manages the .squire/ directory in the workspace root.
@@ -26,6 +27,7 @@ export class SquireDir {
       }
     }
     this.ensureConfig();
+    this.ensureBinScript();
   }
 
   /** Place a .gitignore inside .squire/ to ignore its own contents (never modify project .gitignore) */
@@ -106,6 +108,21 @@ export class SquireDir {
 
     try {
       fs.writeFileSync(configPath, template, 'utf-8');
+    } catch {
+      // Non-critical
+    }
+  }
+
+  /** Install the cross-platform sq.mjs helper script into .squire/bin/ */
+  ensureBinScript(): void {
+    const binDir = path.join(this.dir, 'bin');
+    const scriptPath = path.join(binDir, 'sq.mjs');
+    try {
+      if (!fs.existsSync(binDir)) {
+        fs.mkdirSync(binDir, { recursive: true });
+      }
+      // Always overwrite so updates propagate
+      fs.writeFileSync(scriptPath, SQ_SCRIPT, 'utf-8');
     } catch {
       // Non-critical
     }

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -487,20 +487,21 @@ export class TaskRunner {
 
     terminal.show(false);
 
-    // Inject task-log-id so agents write to the correct JSONL file.
-    // Use bracket syntax [task-log-id:xxx] appended at the END to avoid
-    // interfering with slash command names or CLI flag parsing.
+    // Inject task-log-id and squire-dir so agents write to the correct location.
+    // Use bracket syntax appended at the END to avoid interfering with CLI flag parsing.
     const logIdTag = `[task-log-id:${taskLogId}]`;
+    const squireDirTag = `[squire-dir:${this.squireDir.dir.replace(/\\/g, '/')}]`;
+    const tags = `${logIdTag} ${squireDirTag}`;
     if (launch.agent && launch.initialPrompt) {
-      launch.initialPrompt = `${launch.initialPrompt} ${logIdTag}`;
+      launch.initialPrompt = `${launch.initialPrompt} ${tags}`;
     } else if (launch.agent) {
-      launch.initialPrompt = logIdTag;
+      launch.initialPrompt = tags;
     }
     if (launch.interactivePrompt) {
-      launch.interactivePrompt = `${launch.interactivePrompt} ${logIdTag}`;
+      launch.interactivePrompt = `${launch.interactivePrompt} ${tags}`;
     }
     if (launch.prompt) {
-      launch.prompt = `${launch.prompt} ${logIdTag}`;
+      launch.prompt = `${launch.prompt} ${tags}`;
     }
 
     if (launch.agent) {


### PR DESCRIPTION
## Summary

- **New**: `src/sq-script.ts` — embedded Node.js helper script (`sq.mjs`) installed to `.squire/bin/` at extension init
- **Fix**: Extension now passes `[squire-dir:<abs-path>]` to agents via `task-runner.ts`, eliminating reliance on `git rev-parse` which fails in worktrees
- **Simplify**: Agent prompts (`squire-dev-issue.md` x2) replace ~15 lines of manual JSON echo per phase with single `node sq.mjs log ...` commands

### Problem

LLM agents wrote logs/decisions to wrong paths when running inside git worktrees:
1. `git rev-parse --show-toplevel` returns worktree path, not main repo root
2. Manual JSON construction in bash broke on Windows (PowerShell)
3. LLM frequently forgot multi-step logging operations (write JSON + correct path + mkdir)

### Solution

```
Extension passes [squire-dir:/abs/path/.squire]
  → Agent parses it, uses as $SQUIRE_DIR
    → node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" $TASK_ID event_type "detail" --branch main
      → sq.mjs writes to correct absolute path, constructs JSON, handles timestamps
```

## Test plan

- [x] `npm run compile` passes
- [x] `npm test` — 11/11 tests pass
- [x] `sq.mjs` tested standalone: log, decision, decision-clear all produce correct JSONL/JSON
- [ ] End-to-end: run `/squire-dev-issue` and verify logs appear in `.squire/logs/` (not in worktree)