### PR TITLE
fix(dashboard): simplify watch-pr display and fix review-pr pipeline

### DIFF
--- a/framework/agents/squire-pr-reviewer.md
+++ b/framework/agents/squire-pr-reviewer.md
@@ -167,12 +167,22 @@ For each unresolved comment:
 
 ## Step 3: Act Based on Strategy
 
-**After presenting the review summary, log completion:**
+**After presenting the review summary, log that analysis is complete:**
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_analyzed "Review summary ready" --pr $PR_NUMBER
 ```
 
 Follow the strategy-specific behavior defined above. For `normal`, wait for user input. For `auto` and `quick-approve`, proceed immediately.
+
+**After publishing to GitHub** (auto/quick-approve, or after user confirms in normal):
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_published "Review published" --pr $PR_NUMBER
+```
+
+**When the review task is fully complete** (user says done in normal, or after publishing in auto/quick-approve):
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
+```
 
 ## Step 4: Interactive Discussion (normal strategy)
 
@@ -272,12 +282,17 @@ The extension writes `reviewing` on task start. You handle the rest:
 
 **After presenting the review summary** (all strategies, including own-PR):
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_analyzed "Review summary ready" --pr $PR_NUMBER
 ```
 
-**After publishing a review to GitHub** (auto/quick-approve strategy, NOT own-PR):
+**After publishing a review to GitHub** (auto/quick-approve strategy, or user-confirmed in normal; NOT own-PR):
 ```bash
 node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_published "Review published" --pr $PR_NUMBER
+```
+
+**When the review task is fully complete** (user says done in normal, or after publishing in auto/quick-approve):
+```bash
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" review_done "Review complete" --pr $PR_NUMBER
 ```
 
 Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, and `$PR_NUMBER` with actual values.

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -882,7 +882,7 @@ function renderTasks(list) {
         <span class="task-label">\${esc(t.label || 'Task ' + t.id)}</span>
         <span class="badge \${badgeClass}">\${t.status === 'orphan' ? 'orphan' : esc(latestStatus)}</span>
       </div>
-      <div class="pipeline">\${pipeline}</div>
+      \${isCyclic ? '' : '<div class="pipeline">' + pipeline + '</div>'}
       <div class="task-meta">
         \${t.branch ? t.branch + ' · ' : ''}\${t.prNumber ? 'PR #' + t.prNumber + ' · ' : ''}\${shortTime(t.startedAt)}
         \${t.status === 'running' ? ' · ' + duration(t.startedAt) : ''}

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -814,13 +814,13 @@ function badgeFor(action) {
 // ===== Tasks =====
 function refreshTasks() { vscode.postMessage({ type: 'getTasks' }); }
 const PHASES = ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'];
-const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyzing', exploring: 'Exploring', planning: 'Planning', implementing: 'Implementing', testing: 'Testing', creating_pr: 'Creating PR', done: 'Done', reviewing: 'Reviewing', published: 'Published', monitoring: 'Monitor', fixing_ci: 'Fix CI', fixing_comments: 'Fix Comments' };
+const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyzing', exploring: 'Exploring', planning: 'Planning', implementing: 'Implementing', testing: 'Testing', creating_pr: 'Creating PR', done: 'Done', reviewing: 'Reviewing', reviewed: 'Reviewed', published: 'Published', monitoring: 'Monitor', fixing_ci: 'Fix CI', fixing_comments: 'Fix Comments' };
 // Map internal phases to pipeline display phases
-const PHASE_MAP = { planned: 'planned', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed', reviewing: 'reviewing', published: 'published', monitoring: 'monitoring', fixing_ci: 'fixing_ci', fixing_comments: 'fixing_comments' };
+const PHASE_MAP = { planned: 'planned', analyzing: 'analyzing', exploring: 'exploring', planning: 'planning', implementing: 'implementing', testing: 'testing', test_failed: 'testing', waiting_confirm: 'testing', waiting_manual_test: 'testing', creating_pr: 'creating_pr', done: 'done', failed: 'failed', reviewing: 'reviewing', reviewed: 'reviewed', published: 'published', monitoring: 'monitoring', fixing_ci: 'fixing_ci', fixing_comments: 'fixing_comments' };
 // Per-type pipeline phases
 const PHASE_PIPELINES = {
   'dev-issue':    ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'],
-  'review-pr':    ['reviewing','done','published'],
+  'review-pr':    ['reviewing','reviewed','published','done'],
   'watch-pr':     ['analyzing','monitoring','fixing_ci','fixing_comments','monitoring'],
   'fix-comments': ['analyzing','implementing','testing','creating_pr','done'],
   'run-command':  ['implementing','done'],
@@ -833,7 +833,7 @@ function renderTasks(list) {
   c.innerHTML = list.map(t => {
     var phases = PHASE_PIPELINES[t.type] || PHASE_PIPELINES['dev-issue'];
     // Own PR reviews don't need 'published' step
-    if (t.type === 'review-pr' && t.isOwnPR) phases = ['reviewing', 'done'];
+    if (t.type === 'review-pr' && t.isOwnPR) phases = ['reviewing', 'reviewed', 'done'];
     const isCyclic = CYCLIC_TYPES[t.type] || false;
     const rawPhase = t.phase || 'planned';
     const displayPhase = PHASE_MAP[rawPhase] || phases[0];

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -8,14 +8,14 @@ export type TaskPhase =
   | 'waiting_confirm' | 'waiting_manual_test'
   | 'creating_pr' | 'done' | 'failed'
   // review-pr phases
-  | 'reviewing' | 'published'
+  | 'reviewing' | 'reviewed' | 'published'
   // watch-pr phases
   | 'monitoring' | 'fixing_ci' | 'fixing_comments';
 
 /** Pipeline phases displayed in the dashboard, per task type */
 export const PHASE_PIPELINES: Record<string, TaskPhase[]> = {
   'dev-issue':    ['analyzing', 'exploring', 'planning', 'implementing', 'testing', 'creating_pr', 'done'],
-  'review-pr':    ['reviewing', 'done', 'published'],
+  'review-pr':    ['reviewing', 'reviewed', 'published', 'done'],
   'watch-pr':     ['analyzing', 'monitoring', 'fixing_ci', 'fixing_comments', 'monitoring'],
   'fix-comments': ['analyzing', 'implementing', 'testing', 'creating_pr', 'done'],
   'run-command':  ['implementing', 'done'],
@@ -94,6 +94,7 @@ const EVENT_TYPE_TO_PHASE: Record<string, TaskPhase> = {
   pr_merged: 'done',
   worktree_cleaned: 'done',
   // review-pr events
+  review_analyzed: 'reviewed',
   review_done: 'done',
   review_published: 'published',
   // watch-pr events
@@ -114,7 +115,7 @@ const VALID_PHASES = new Set<string>([
   'implementing', 'testing', 'test_failed',
   'waiting_confirm', 'waiting_manual_test',
   'creating_pr', 'done', 'failed',
-  'reviewing', 'published',
+  'reviewing', 'reviewed', 'published',
   'monitoring', 'fixing_ci', 'fixing_comments',
 ]);
 


### PR DESCRIPTION
## Summary

- **watch-pr**: Hide pipeline progress bar for cyclic tasks — only show status badge
- **review-pr**: Add `reviewed` phase so pipeline shows proper progress (`reviewing → reviewed → published → done`). Previously `review_done` fired immediately after summary, making the task appear complete before the user had a chance to act.

### Changes
- `dashboard-html.ts` — skip pipeline div for cyclic types; add `reviewed` to PHASE_LABELS/PHASE_MAP/PHASE_PIPELINES
- `task-state.ts` — add `reviewed` phase type, `review_analyzed` event mapping, update pipeline definition
- `squire-pr-reviewer.md` — log `review_analyzed` after summary, `review_published` after publish, `review_done` only when fully complete

## Test plan

- [x] `npm run compile` passes
- [x] `npm test` — 11/11 tests pass
- [ ] End-to-end: verify watch-pr task card shows badge only (no progress bar)
- [ ] End-to-end: verify review-pr task card shows `Reviewed` after summary, `Done` only after completion