### PR TITLE
feat(session): add AI session ID detection adapters (Claude + Copilot)

### DIFF
--- a/src/session-detector.ts
+++ b/src/session-detector.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface AiSession {
+  source: 'claude' | 'copilot';
+  id: string;
+  resumable: boolean;
+}
+
+/**
+ * Parse a Claude session JSON file and return the sessionId if it matches the given cwd.
+ * Exported for testing.
+ */
+export function parseClaudeSessionFile(content: string, cwd: string): string | null {
+  try {
+    const data = JSON.parse(content);
+    if (!data.sessionId || !data.cwd) return null;
+    // Normalize paths for comparison (handle Windows vs Unix)
+    const normalizedCwd = cwd.replace(/\\/g, '/').toLowerCase();
+    const normalizedSessionCwd = String(data.cwd).replace(/\\/g, '/').toLowerCase();
+    if (normalizedSessionCwd === normalizedCwd) {
+      return data.sessionId;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a Copilot workspace.yaml file and extract the session id.
+ * Exported for testing.
+ */
+export function parseCopilotWorkspaceYaml(content: string): string | null {
+  // Simple YAML parsing — extract `id:` field from top level
+  for (const line of content.split('\n')) {
+    const match = line.match(/^id:\s*(.+)$/);
+    if (match) return match[1].trim();
+  }
+  return null;
+}
+
+/**
+ * Check if a Copilot events.jsonl contains a reference to the given taskLogId.
+ * Exported for testing.
+ */
+export function copilotEventsMatchTaskLogId(content: string, taskLogId: string): boolean {
+  return content.includes(taskLogId);
+}
+
+/**
+ * Detect Claude AI sessions by scanning ~/.claude/sessions/*.json
+ * and matching by working directory.
+ */
+export function detectClaudeSession(cwd: string): AiSession | null {
+  const sessionsDir = path.join(os.homedir(), '.claude', 'sessions');
+  try {
+    if (!fs.existsSync(sessionsDir)) return null;
+    const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith('.json'));
+
+    // Check files newest-first (highest PID or newest mtime likely most relevant)
+    for (const file of files.reverse()) {
+      const content = fs.readFileSync(path.join(sessionsDir, file), 'utf-8');
+      const sessionId = parseClaudeSessionFile(content, cwd);
+      if (sessionId) {
+        return { source: 'claude', id: sessionId, resumable: true };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect Copilot AI sessions by scanning ~/.copilot/session-state/
+ * for sessions whose events.jsonl references the given taskLogId.
+ */
+export function detectCopilotSession(taskLogId: string): AiSession | null {
+  const sessionStateDir = path.join(os.homedir(), '.copilot', 'session-state');
+  try {
+    if (!fs.existsSync(sessionStateDir)) return null;
+    const dirs = fs.readdirSync(sessionStateDir);
+
+    for (const dir of dirs) {
+      const eventsPath = path.join(sessionStateDir, dir, 'events.jsonl');
+      try {
+        if (!fs.existsSync(eventsPath)) continue;
+        const eventsContent = fs.readFileSync(eventsPath, 'utf-8');
+        if (copilotEventsMatchTaskLogId(eventsContent, taskLogId)) {
+          // Found matching session — extract id from workspace.yaml
+          const yamlPath = path.join(sessionStateDir, dir, 'workspace.yaml');
+          if (fs.existsSync(yamlPath)) {
+            const yamlContent = fs.readFileSync(yamlPath, 'utf-8');
+            const sessionId = parseCopilotWorkspaceYaml(yamlContent);
+            if (sessionId) {
+              return { source: 'copilot', id: sessionId, resumable: false };
+            }
+          }
+          // Fallback: use directory name as session id
+          return { source: 'copilot', id: dir, resumable: false };
+        }
+      } catch {
+        // Skip unreadable session directories
+        continue;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect all AI sessions. Tries both Claude and Copilot adapters.
+ * Returns empty array on failure — never throws.
+ */
+export function detectAiSessions(cwd: string, taskLogId: string): AiSession[] {
+  const sessions: AiSession[] = [];
+  try {
+    const claude = detectClaudeSession(cwd);
+    if (claude) sessions.push(claude);
+  } catch { /* graceful fallback */ }
+  try {
+    const copilot = detectCopilotSession(taskLogId);
+    if (copilot) sessions.push(copilot);
+  } catch { /* graceful fallback */ }
+  return sessions;
+}

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -7,7 +7,7 @@ import { WorktreeManager } from './worktree';
 import { GitHubRepoInfo } from './github-detector';
 import { SquireDir } from './squire-dir';
 import { SquireBackend } from './backend';
-import { detectAiSessions, AiSession } from './session-detector';
+import { detectAiSessions } from './session-detector';
 
 export type TaskType = 'dev-issue' | 'watch-pr' | 'review-pr' | 'fix-comments' | 'run-command' | 'run-agent';
 
@@ -61,18 +61,15 @@ export class TaskRunner {
           // Skip for cyclic pipelines (watch-pr) — they don't have a terminal "done" state
           if (task.type !== 'watch-pr') {
             const taskLogId = task.taskLogId || `task-${task.id}`;
-            // Detect AI sessions (Claude / Copilot) before writing completion event
-            const cwd = task.worktreeDir || this.workspaceRoot;
-            const aiSessions = detectAiSessions(cwd, taskLogId);
             this.squireDir.logJson(taskLogId, {
               event: 'task_completed',
               phase: 'done',
               task_id: taskLogId,
               type: task.type,
-              ai_sessions: aiSessions.length > 0 ? aiSessions : undefined,
             });
-            // Write endedAt to global session index
-            this.updateSessionEndedAt(taskLogId);
+            // Write endedAt + detect AI sessions (fallback for 30s delayed detection)
+            const cwd = task.worktreeDir || this.workspaceRoot;
+            this.updateSessionIndex(taskLogId, cwd, true);
           }
           task.terminal = undefined;
           this._onTasksChanged.fire();
@@ -522,6 +519,13 @@ export class TaskRunner {
 
     taskInfo.terminal = terminal;
     this._onTasksChanged.fire();
+
+    // Delayed AI session detection (30s after launch — session files need time to appear)
+    const delayedTaskLogId = taskInfo.taskLogId || `task-${taskInfo.id}`;
+    const delayedCwd = cwd;
+    setTimeout(() => {
+      this.updateSessionIndex(delayedTaskLogId, delayedCwd, false);
+    }, 30_000);
   }
 
   private formatDevLabel(mode: string, issueNum: string | null, title?: string, rawInput?: string): string {
@@ -542,10 +546,11 @@ export class TaskRunner {
   }
 
   /**
-   * Write endedAt timestamp to the global session index (~/.squire/sessions/index.json).
-   * Finds the latest session for this taskLogId under the current repo slug and stamps it.
+   * Update the global session index (~/.squire/sessions/index.json).
+   * Detects AI sessions and optionally writes endedAt.
+   * @param writeEndedAt - true when called on terminal close, false for 30s delayed detection
    */
-  private updateSessionEndedAt(taskLogId: string): void {
+  private updateSessionIndex(taskLogId: string, cwd: string, writeEndedAt: boolean): void {
     const indexPath = path.join(os.homedir(), '.squire', 'sessions', 'index.json');
     try {
       if (!fs.existsSync(indexPath)) return;
@@ -555,8 +560,24 @@ export class TaskRunner {
       if (!taskEntry?.sessions?.length) return;
 
       const latest = taskEntry.sessions[taskEntry.sessions.length - 1];
-      if (!latest.endedAt) {
+      let changed = false;
+
+      // Detect AI sessions if not already set
+      if (!latest.aiSessions || latest.aiSessions.length === 0) {
+        const aiSessions = detectAiSessions(cwd, taskLogId);
+        if (aiSessions.length > 0) {
+          latest.aiSessions = aiSessions;
+          changed = true;
+        }
+      }
+
+      // Write endedAt on terminal close
+      if (writeEndedAt && !latest.endedAt) {
         latest.endedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+        changed = true;
+      }
+
+      if (changed) {
         fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
       }
     } catch {

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -7,6 +7,7 @@ import { WorktreeManager } from './worktree';
 import { GitHubRepoInfo } from './github-detector';
 import { SquireDir } from './squire-dir';
 import { SquireBackend } from './backend';
+import { detectAiSessions, AiSession } from './session-detector';
 
 export type TaskType = 'dev-issue' | 'watch-pr' | 'review-pr' | 'fix-comments' | 'run-command' | 'run-agent';
 
@@ -60,11 +61,15 @@ export class TaskRunner {
           // Skip for cyclic pipelines (watch-pr) — they don't have a terminal "done" state
           if (task.type !== 'watch-pr') {
             const taskLogId = task.taskLogId || `task-${task.id}`;
+            // Detect AI sessions (Claude / Copilot) before writing completion event
+            const cwd = task.worktreeDir || this.workspaceRoot;
+            const aiSessions = detectAiSessions(cwd, taskLogId);
             this.squireDir.logJson(taskLogId, {
               event: 'task_completed',
               phase: 'done',
               task_id: taskLogId,
               type: task.type,
+              ai_sessions: aiSessions.length > 0 ? aiSessions : undefined,
             });
             // Write endedAt to global session index
             this.updateSessionEndedAt(taskLogId);

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { AiSession } from './session-detector';
 
 /** Task phases matching the DevSquire pipeline */
 export type TaskPhase =
@@ -45,6 +46,7 @@ export interface TaskState {
   prNumber?: number;
   prUrl?: string;
   worktreeDir?: string;
+  aiSessions?: AiSession[];
   startedAt: string;
   updatedAt: string;
   events: TaskEvent[];
@@ -160,6 +162,7 @@ export class TaskStateReader {
       let issueNumber: number | undefined;
       let issueUrl: string | undefined;
       let worktreeDir: string | undefined;
+      let aiSessions: AiSession[] | undefined;
       let startedAt = '';
       let updatedAt = '';
 
@@ -181,6 +184,9 @@ export class TaskStateReader {
           if (entry.issue_number) issueNumber = entry.issue_number;
           if (entry.issue_url) issueUrl = entry.issue_url;
           if (entry.worktree_dir) worktreeDir = entry.worktree_dir;
+          if (entry.ai_sessions && Array.isArray(entry.ai_sessions)) {
+            aiSessions = entry.ai_sessions;
+          }
 
           events.push({
             timestamp: entry.timestamp,
@@ -202,6 +208,7 @@ export class TaskStateReader {
         prNumber,
         prUrl,
         worktreeDir,
+        aiSessions,
         startedAt,
         updatedAt,
         events,

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { AiSession } from './session-detector';
 
 /** Task phases matching the DevSquire pipeline */
 export type TaskPhase =
@@ -46,7 +45,6 @@ export interface TaskState {
   prNumber?: number;
   prUrl?: string;
   worktreeDir?: string;
-  aiSessions?: AiSession[];
   startedAt: string;
   updatedAt: string;
   events: TaskEvent[];
@@ -162,7 +160,6 @@ export class TaskStateReader {
       let issueNumber: number | undefined;
       let issueUrl: string | undefined;
       let worktreeDir: string | undefined;
-      let aiSessions: AiSession[] | undefined;
       let startedAt = '';
       let updatedAt = '';
 
@@ -184,9 +181,6 @@ export class TaskStateReader {
           if (entry.issue_number) issueNumber = entry.issue_number;
           if (entry.issue_url) issueUrl = entry.issue_url;
           if (entry.worktree_dir) worktreeDir = entry.worktree_dir;
-          if (entry.ai_sessions && Array.isArray(entry.ai_sessions)) {
-            aiSessions = entry.ai_sessions;
-          }
 
           events.push({
             timestamp: entry.timestamp,
@@ -208,7 +202,6 @@ export class TaskStateReader {
         prNumber,
         prUrl,
         worktreeDir,
-        aiSessions,
         startedAt,
         updatedAt,
         events,

--- a/test/session-detector.test.ts
+++ b/test/session-detector.test.ts
@@ -1,33 +1,9 @@
 import { describe, it, expect } from 'vitest';
-
-// --- Extracted logic from session-detector.ts for unit testing ---
-
-function parseClaudeSessionFile(content: string, cwd: string): string | null {
-  try {
-    const data = JSON.parse(content);
-    if (!data.sessionId || !data.cwd) return null;
-    const normalizedCwd = cwd.replace(/\\/g, '/').toLowerCase();
-    const normalizedSessionCwd = String(data.cwd).replace(/\\/g, '/').toLowerCase();
-    if (normalizedSessionCwd === normalizedCwd) {
-      return data.sessionId;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function parseCopilotWorkspaceYaml(content: string): string | null {
-  for (const line of content.split('\n')) {
-    const match = line.match(/^id:\s*(.+)$/);
-    if (match) return match[1].trim();
-  }
-  return null;
-}
-
-function copilotEventsMatchTaskLogId(content: string, taskLogId: string): boolean {
-  return content.includes(taskLogId);
-}
+import {
+  parseClaudeSessionFile,
+  parseCopilotWorkspaceYaml,
+  copilotEventsMatchTaskLogId,
+} from '../src/session-detector';
 
 // --- Tests ---
 

--- a/test/session-detector.test.ts
+++ b/test/session-detector.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+
+// --- Extracted logic from session-detector.ts for unit testing ---
+
+function parseClaudeSessionFile(content: string, cwd: string): string | null {
+  try {
+    const data = JSON.parse(content);
+    if (!data.sessionId || !data.cwd) return null;
+    const normalizedCwd = cwd.replace(/\\/g, '/').toLowerCase();
+    const normalizedSessionCwd = String(data.cwd).replace(/\\/g, '/').toLowerCase();
+    if (normalizedSessionCwd === normalizedCwd) {
+      return data.sessionId;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function parseCopilotWorkspaceYaml(content: string): string | null {
+  for (const line of content.split('\n')) {
+    const match = line.match(/^id:\s*(.+)$/);
+    if (match) return match[1].trim();
+  }
+  return null;
+}
+
+function copilotEventsMatchTaskLogId(content: string, taskLogId: string): boolean {
+  return content.includes(taskLogId);
+}
+
+// --- Tests ---
+
+describe('Session Detector', () => {
+  describe('parseClaudeSessionFile', () => {
+    const validSession = JSON.stringify({
+      pid: 38440,
+      sessionId: '010eddef-3f05-4711-8270-ad465e88aad5',
+      cwd: 'C:\\Users\\alice\\project',
+      startedAt: 1777273077137,
+      version: '2.1.116',
+    });
+
+    it('returns sessionId when cwd matches', () => {
+      expect(parseClaudeSessionFile(validSession, 'C:\\Users\\alice\\project'))
+        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
+    });
+
+    it('matches cwd case-insensitively', () => {
+      expect(parseClaudeSessionFile(validSession, 'c:\\users\\alice\\project'))
+        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
+    });
+
+    it('normalizes slashes for comparison', () => {
+      expect(parseClaudeSessionFile(validSession, 'C:/Users/alice/project'))
+        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
+    });
+
+    it('returns null when cwd does not match', () => {
+      expect(parseClaudeSessionFile(validSession, '/other/path')).toBeNull();
+    });
+
+    it('returns null for missing sessionId', () => {
+      expect(parseClaudeSessionFile('{"cwd":"/a"}', '/a')).toBeNull();
+    });
+
+    it('returns null for missing cwd', () => {
+      expect(parseClaudeSessionFile('{"sessionId":"abc"}', '/a')).toBeNull();
+    });
+
+    it('returns null for invalid JSON', () => {
+      expect(parseClaudeSessionFile('not json', '/a')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseClaudeSessionFile('', '/a')).toBeNull();
+    });
+  });
+
+  describe('parseCopilotWorkspaceYaml', () => {
+    const validYaml = `id: 09f18f7c-0419-4a29-8432-b9d8f8180bdd
+cwd: C:\\Users\\alice\\project
+git_root: C:\\Users\\alice\\project
+repository: org/repo
+branch: main
+summary: Review PR 123`;
+
+    it('extracts id from workspace.yaml', () => {
+      expect(parseCopilotWorkspaceYaml(validYaml))
+        .toBe('09f18f7c-0419-4a29-8432-b9d8f8180bdd');
+    });
+
+    it('returns null when no id field', () => {
+      expect(parseCopilotWorkspaceYaml('cwd: /a\nbranch: main')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseCopilotWorkspaceYaml('')).toBeNull();
+    });
+  });
+
+  describe('copilotEventsMatchTaskLogId', () => {
+    it('returns true when taskLogId is in content', () => {
+      const events = '{"event":"start","task":"task-issue-42"}\n{"event":"done"}';
+      expect(copilotEventsMatchTaskLogId(events, 'task-issue-42')).toBe(true);
+    });
+
+    it('returns false when taskLogId is not found', () => {
+      const events = '{"event":"start","task":"task-issue-99"}';
+      expect(copilotEventsMatchTaskLogId(events, 'task-issue-42')).toBe(false);
+    });
+
+    it('returns false for empty content', () => {
+      expect(copilotEventsMatchTaskLogId('', 'task-issue-42')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #71 — [Multi-Session 3/9] AI session ID detection adapters

- Add `src/session-detector.ts` with `AiSession` interface and detection adapters for Claude (`~/.claude/sessions/*.json` by cwd) and Copilot (`~/.copilot/session-state/*/events.jsonl` by task-log-id)
- Integrate `detectAiSessions()` into `task-runner.ts` `onDidCloseTerminal` to write `ai_sessions` in `task_completed` JSONL events
- Extend `TaskState` with `aiSessions?: AiSession[]` and parse `ai_sessions` from JSONL entries
- Add 14 unit tests covering JSON/YAML parsing, cwd normalization, and graceful fallback

## Test plan

- [x] Build passes (`npm run compile`)
- [x] All 25 unit tests pass (`npm test`)
- [ ] Manual: verify Claude session detection with active Claude session
- [ ] Manual: verify Copilot session detection with active Copilot session