### PR TITLE
feat(task-runner): add session locking and chat mode support

### DIFF
--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -506,6 +506,7 @@ input:focus { outline: none; border-color: var(--focus); box-shadow: 0 0 0 1px v
       <select id="manualMode" class="btn-s">
         <option value="auto" \${defaultMode === 'auto' ? 'selected' : ''}>Auto</option>
         <option value="normal" \${defaultMode === 'normal' ? 'selected' : ''}>Normal</option>
+        <option value="chat" \${defaultMode === 'chat' ? 'selected' : ''}>Chat</option>
       </select>
       <button onclick="submitManualIssue()">Go</button>
     </div>
@@ -681,6 +682,7 @@ function renderIssues(list) {
         <select class="btn-s" id="mode-\${i.number}" onclick="event.stopPropagation()">
           <option value="auto" \${defaultMode==='auto'?'selected':''}>Auto</option>
           <option value="normal" \${defaultMode==='normal'?'selected':''}>Normal</option>
+          <option value="chat" \${defaultMode==='chat'?'selected':''}>Chat</option>
         </select>
         <button class="btn-s btn-pri" onclick="event.stopPropagation();assignIssue(\${i.number})">Assign</button>
       </span>
@@ -857,6 +859,7 @@ function renderTasks(list) {
     var phases = PHASE_PIPELINES[t.type] || PHASE_PIPELINES['dev-issue'];
     // Own PR reviews don't need 'published' step
     if (t.type === 'review-pr' && t.isOwnPR) phases = ['reviewing', 'reviewed', 'done'];
+    const isChat = t.label && t.label.startsWith('[Chat]');
     const isCyclic = CYCLIC_TYPES[t.type] || false;
     const rawPhase = t.phase || 'planned';
     const displayPhase = PHASE_MAP[rawPhase] || phases[0];
@@ -943,7 +946,7 @@ function renderTasks(list) {
         <span class="task-label">\${esc(t.label || 'Task ' + t.id)}</span>
         <span class="badge \${badgeClass}">\${t.status === 'orphan' ? 'orphan' : esc(latestStatus)}</span>
       </div>
-      \${isCyclic ? '' : '<div class="pipeline">' + pipeline + '</div>'}
+      \${isCyclic || isChat ? '' : '<div class="pipeline">' + pipeline + '</div>'}
       <div class="task-meta">
         \${t.branch ? t.branch + ' · ' : ''}\${t.prNumber ? 'PR #' + t.prNumber + ' · ' : ''}\${shortTime(t.startedAt)}
         \${t.status === 'running' ? ' · ' + duration(t.startedAt) : ''}

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -88,15 +88,16 @@ export class TaskRunner {
   }
 
   /** Run /squire-dev-issue — matches dashboard assign command */
-  async runDevIssue(issueInput: string, mode?: 'normal' | 'auto', issueTitle?: string): Promise<TaskInfo> {
-    const effectiveMode = mode || vscode.workspace.getConfiguration('devSquire').get<string>('devIssue.mode', 'auto') as 'normal' | 'auto';
+  async runDevIssue(issueInput: string, mode?: 'normal' | 'auto' | 'chat', issueTitle?: string): Promise<TaskInfo> {
+    const effectiveMode = mode || vscode.workspace.getConfiguration('devSquire').get<string>('devIssue.mode', 'auto') as 'normal' | 'auto' | 'chat';
     const issueNum = this.extractIssueNumber(issueInput);
     const issueUrl = issueNum
       ? `${this.repoUrl}/issues/${issueNum}`
       : issueInput;
 
     // Duplicate detection: check if a task with same issue is already running
-    if (issueNum) {
+    // Chat mode allows concurrent sessions on the same issue
+    if (issueNum && effectiveMode !== 'chat') {
       for (const t of this.tasks.values()) {
         if (t.status === 'running' && t.issueUrl === issueUrl) {
           vscode.window.showWarningMessage(`DevSquire: Issue #${issueNum} already has a running task.`);
@@ -108,16 +109,20 @@ export class TaskRunner {
 
     const branchName = issueNum ? `dev/issue-${issueNum}` : `dev/task-${Date.now()}`;
 
-    const wt = this.worktree.create(this.workspaceRoot, branchName);
+    // Chat mode: no worktree, run in workspace root
+    const isChat = effectiveMode === 'chat';
+    const wt = isChat ? undefined : this.worktree.create(this.workspaceRoot, branchName);
 
-    const terminalTitle = issueNum
-      ? `Squire: Dev #${issueNum}`
-      : `Squire: dev-adhoc-${Date.now()}`;
+    const terminalTitle = isChat
+      ? (issueNum ? `Squire: Chat #${issueNum}` : `Squire: Chat`)
+      : issueNum
+        ? `Squire: Dev #${issueNum}`
+        : `Squire: dev-adhoc-${Date.now()}`;
 
-    const autoFlag = effectiveMode === 'auto' ? '--auto ' : '';
+    const modeFlag = effectiveMode === 'auto' ? '--auto ' : effectiveMode === 'chat' ? '--chat ' : '';
     const agentArgs: AgentLaunch = {
       agent: 'squire-dev-issue',
-      initialPrompt: `${autoFlag}${issueUrl}`,
+      initialPrompt: `${modeFlag}${issueUrl}`,
     };
 
     const ts = Date.now();
@@ -128,8 +133,8 @@ export class TaskRunner {
       type: 'dev-issue',
       label: this.formatDevLabel(effectiveMode, issueNum, issueTitle, issueInput),
       issueUrl,
-      worktreeBranch: branchName,
-      worktreeDir: wt?.path,
+      worktreeBranch: isChat ? undefined : branchName,
+      worktreeDir: isChat ? undefined : wt?.path,
       status: 'running',
       createdAt: ts,
     };
@@ -217,8 +222,8 @@ export class TaskRunner {
   }
 
   /** Fix PR comments via squire-dev-issue agent */
-  async runFixComments(prNumber: number, mode?: 'normal' | 'auto'): Promise<TaskInfo> {
-    const effectiveMode = mode || vscode.workspace.getConfiguration('devSquire').get<string>('fixComments.mode', 'auto') as 'normal' | 'auto';
+  async runFixComments(prNumber: number, mode?: 'normal' | 'auto' | 'chat'): Promise<TaskInfo> {
+    const effectiveMode = mode || vscode.workspace.getConfiguration('devSquire').get<string>('fixComments.mode', 'auto') as 'normal' | 'auto' | 'chat';
     const autoFlag = effectiveMode === 'auto' ? '--auto ' : '';
     const agentArgs: AgentLaunch = {
       agent: 'squire-dev-issue',
@@ -529,7 +534,7 @@ export class TaskRunner {
   }
 
   private formatDevLabel(mode: string, issueNum: string | null, title?: string, rawInput?: string): string {
-    const modeTag = mode === 'auto' ? '[Auto]' : '[Normal]';
+    const modeTag = mode === 'auto' ? '[Auto]' : mode === 'chat' ? '[Chat]' : '[Normal]';
     if (issueNum) {
       const suffix = title ? ` ${title}` : '';
       return `${modeTag} Dev #${issueNum}${suffix}`;


### PR DESCRIPTION
## Summary
- Add chat mode to `runDevIssue` that bypasses duplicate detection, skips worktree creation, and passes `--chat` flag to agent — resolving [#74](https://github.com/frankliu20/DevSquire/issues/74)
- Update dashboard UI to include "Chat" option in mode selectors and hide pipeline dots for chat sessions
- Expand mode type to `'normal' | 'auto' | 'chat'` across `runDevIssue` and `runFixComments`

## Test plan
- [x] Build passes
- [ ] Verify chat mode creates no worktree and runs in workspace root
- [ ] Verify concurrent chat sessions on same issue are allowed
- [ ] Verify dashboard shows Chat option and hides pipeline for chat tasks