### PR TITLE
refactor(tasks): rework task cleanup lifecycle

### DIFF
--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -289,7 +289,7 @@ input:focus { outline: none; border-color: var(--focus); box-shadow: 0 0 0 1px v
 .task-card.running { border-left: 3px solid var(--yellow); }
 .task-card.done { border-left: 3px solid var(--green); }
 .task-card.failed { border-left: 3px solid var(--red); }
-.task-card.orphan { border-left: 3px solid var(--fg-muted); opacity: 0.75; }
+.task-card.completed { border-left: 3px solid var(--fg-muted); opacity: 0.75; }
 .task-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--sp-1); }
 .task-label { font-weight: 600; font-size: var(--text-base); }
 .task-meta { font-size: var(--text-xs); color: var(--fg-muted); margin-bottom: var(--sp-1); font-family: var(--font-mono); }
@@ -661,7 +661,7 @@ function issueTaskId(num) {
 }
 function phaseBadge(phase) {
   if (!phase) return '';
-  const map = { done: 'badge-green', failed: 'badge-red', orphan: 'badge-neutral', implementing: 'badge-blue', testing: 'badge-yellow', exploring: 'badge-blue', analyzing: 'badge-blue', planning: 'badge-purple', creating_pr: 'badge-purple', planned: 'badge-neutral' };
+  const map = { done: 'badge-green', failed: 'badge-red', completed: 'badge-neutral', implementing: 'badge-blue', testing: 'badge-yellow', exploring: 'badge-blue', analyzing: 'badge-blue', planning: 'badge-purple', creating_pr: 'badge-purple', planned: 'badge-neutral' };
   const cls = Object.entries(map).find(([k]) => phase.includes(k))?.[1] || 'badge-neutral';
   return '<span class="badge ' + cls + '">' + esc(phase) + '</span>';
 }
@@ -863,7 +863,7 @@ function renderTasks(list) {
     // For cyclic pipelines, find the last occurrence to handle repeated phases (e.g. monitoring appears twice)
     const phaseIdx = isCyclic ? phases.lastIndexOf(displayPhase) : phases.indexOf(displayPhase);
     const isFailed = rawPhase === 'failed' || rawPhase === 'test_failed';
-    const phaseClass = (!isCyclic && rawPhase === 'done') ? 'done' : isFailed ? 'failed' : t.status === 'orphan' ? 'orphan' : t.status === 'running' ? 'running' : '';
+    const phaseClass = (!isCyclic && rawPhase === 'done') ? 'done' : isFailed ? 'failed' : t.status === 'completed' ? 'completed' : t.status === 'running' ? 'running' : '';
     // For cyclic: show unique steps, only highlight current; for linear: show progress bar
     const displayPhases = isCyclic ? phases : (phases.length <= 2 ? phases : phases.filter(p => p !== 'done'));
     const pipeline = displayPhases.map((p, i) => {
@@ -871,11 +871,11 @@ function renderTasks(list) {
       if (isCyclic) {
         // Cyclic: only highlight the current step, don't mark previous as done
         if (isFailed && i === phaseIdx) cls = 'failed';
-        else if (i === phaseIdx && (t.status === 'running' || t.status === 'orphan')) cls = 'active';
+        else if (i === phaseIdx && t.status === 'running') cls = 'active';
       } else {
         if (isFailed && i === phaseIdx) cls = 'failed';
         else if (rawPhase === 'done' || i < phaseIdx) cls = 'done';
-        else if (i === phaseIdx && (t.status === 'running' || t.status === 'orphan')) cls = 'active';
+        else if (i === phaseIdx && t.status === 'running') cls = 'active';
       }
       return '<div class="pipeline-step ' + cls + '"><div class="pipeline-bar"></div><div class="pipeline-label">' + (PHASE_LABELS[p] || p) + '</div></div>';
     }).join('');
@@ -891,7 +891,7 @@ function renderTasks(list) {
       if (msg && typeof msg === 'string' && msg.length > 1) latestStatus = msg;
     }
     if (t.waiting) latestStatus += ' ⏳';
-    var badgeClass = (!isCyclic && rawPhase === 'done') ? 'badge-green' : isFailed ? 'badge-red' : t.status === 'orphan' ? 'badge-neutral' : 'badge-yellow';
+    var badgeClass = (!isCyclic && rawPhase === 'done') ? 'badge-green' : isFailed ? 'badge-red' : t.status === 'completed' ? 'badge-neutral' : 'badge-yellow';
 
     const eventsHtml = t.events && expandedTask === t.id
       ? '<div class="event-log">' + t.events.slice(-15).map(e =>
@@ -941,7 +941,7 @@ function renderTasks(list) {
     <div class="task-card \${phaseClass}" onclick="toggleTaskEvents('\${t.id}')">
       <div class="task-header">
         <span class="task-label">\${esc(t.label || 'Task ' + t.id)}</span>
-        <span class="badge \${badgeClass}">\${t.status === 'orphan' ? 'orphan' : esc(latestStatus)}</span>
+        <span class="badge \${badgeClass}">\${esc(latestStatus)}</span>
       </div>
       \${isCyclic ? '' : '<div class="pipeline">' + pipeline + '</div>'}
       <div class="task-meta">
@@ -951,9 +951,9 @@ function renderTasks(list) {
       <div class="task-actions">
         \${t.hasTerminal ? '<button class="btn btn-pri" onclick="event.stopPropagation();focusTerminal(\\''+t.id+'\\')">Terminal</button>' : ''}
         \${t.worktreeDir ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>' : ''}
-        \${t.status === 'orphan' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();cleanupOrphan(\\''+t.id+'\\')">Clean</button>' : ''}
-        \${t.status !== 'running' && t.status !== 'orphan' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))">Clean</button>' : ''}
-        \${t.status === 'running' ? '<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Send Ctrl+C to the terminal.\\',()=>killTask(\\''+t.id+'\\'))">Stop</button>' : ''}
+        \${t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')">Dismiss</button>' : ''}
+        \${t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))">Clean</button>' : ''}
+        \${t.status === 'running' ? '<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal and mark completed.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>' : ''}
       </div>
       \${eventsHtml}
       \${sessionsHtml}
@@ -961,9 +961,9 @@ function renderTasks(list) {
   }).join('');
 }
 function toggleTaskEvents(id) { expandedTask = expandedTask === id ? null : id; renderTasks(tasks); }
-function killTask(id) { vscode.postMessage({ type: 'killTask', taskId: id }); }
+function stopTask(id) { vscode.postMessage({ type: 'stopTask', taskId: id }); }
+function dismissTask(id) { vscode.postMessage({ type: 'dismissTask', taskId: id }); }
 function cleanupTask(id) { vscode.postMessage({ type: 'cleanupTask', taskId: id }); }
-function cleanupOrphan(id) { vscode.postMessage({ type: 'cleanupOrphan', taskId: id }); }
 function cleanAll() { vscode.postMessage({ type: 'cleanAll' }); }
 function syncMain() { vscode.postMessage({ type: 'syncMain' }); }
 function offWork() {
@@ -1225,7 +1225,7 @@ window.addEventListener('message', e => {
       break;
     case 'tasks':
       tasks = msg.data;
-      document.getElementById('statTasks').textContent = tasks.filter(t => t.status === 'running' || t.status === 'orphan').length;
+      document.getElementById('statTasks').textContent = tasks.filter(t => t.status === 'running').length;
       renderTasks(tasks);
       if (issuesLoaded) filterIssues(); // refresh issue phase badges
       break;

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -160,21 +160,23 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
         this.taskRunner.runWatchPRs();
         break;
       }
-      case 'killTask': {
-        this.taskRunner.killTask(msg.taskId);
+      case 'stopTask': {
+        this.taskRunner.stopTask(msg.taskId);
+        break;
+      }
+      case 'dismissTask': {
+        this.taskRunner.dismissTask(msg.taskId);
+        this.sendTasks();
         break;
       }
       case 'cleanupTask': {
-        this.taskRunner.cleanupTask(msg.taskId);
-        break;
-      }
-      case 'cleanupOrphan': {
-        this.taskRunner.cleanOrphanTask(msg.taskId);
+        this.taskRunner.cleanTask(msg.taskId);
         this.sendTasks();
         break;
       }
       case 'cleanAll': {
         this.taskRunner.cleanAll();
+        this.sendTasks();
         break;
       }
       case 'syncMain': {
@@ -327,7 +329,7 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
           id: lt.id,
           label: lt.issueNumber ? `Issue #${lt.issueNumber}` : lt.id,
           type: 'dev-issue' as const,
-          status: lt.phase === 'done' ? 'completed' as const : lt.phase === 'failed' ? 'failed' as const : 'orphan' as const,
+          status: lt.phase === 'done' ? 'completed' as const : lt.phase === 'failed' ? 'failed' as const : 'completed' as const,
           phase: lt.phase,
           branch: lt.branch,
           prNumber: lt.prNumber,

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -22,7 +22,7 @@ export interface TaskInfo {
   worktreeBranch?: string;
   worktreeDir?: string;
   terminal?: vscode.Terminal;
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'orphan';
+  status: 'pending' | 'running' | 'completed' | 'failed';
   createdAt: number;
 }
 
@@ -320,18 +320,44 @@ export class TaskRunner {
     return undefined;
   }
 
-  killTask(taskId: string): void {
+  /** Stop a running task: close terminal, mark completed */
+  stopTask(taskId: string): void {
     const found = this.findTask(taskId);
     if (found?.[1]?.terminal) {
       const task = found[1];
-      task.terminal.sendText('\x03', false); // Ctrl+C
-      task.status = 'failed';
+      task.terminal.dispose();
+      task.status = 'completed';
+      // Write completion event to JSONL + update session index
+      if (task.type !== 'watch-pr') {
+        const taskLogId = task.taskLogId || `task-${task.id}`;
+        this.squireDir.logJson(taskLogId, {
+          event: 'task_completed',
+          phase: 'done',
+          task_id: taskLogId,
+          type: task.type,
+        });
+        const cwd = task.worktreeDir || this.workspaceRoot;
+        this.updateSessionIndex(taskLogId, cwd, true);
+      }
+      task.terminal = undefined;
       this._onTasksChanged.fire();
-      this.squireDir.log('extension', `Task ${taskId} killed by user`);
+      this.squireDir.log('extension', `Task ${taskId} stopped by user`);
     }
   }
 
-  cleanupTask(taskId: string): void {
+  /** Dismiss a completed/failed task: hide from dashboard, preserve all disk data */
+  dismissTask(taskId: string): void {
+    const found = this.findTask(taskId);
+    if (found) {
+      const [runtimeId] = found;
+      this.tasks.delete(runtimeId);
+    }
+    this._onTasksChanged.fire();
+    this.squireDir.log('extension', `Task ${taskId} dismissed`);
+  }
+
+  /** Clean a task: delete worktree + log + decisions, preserve global session index */
+  cleanTask(taskId: string): void {
     const found = this.findTask(taskId);
     if (found) {
       const [runtimeId, task] = found;
@@ -341,56 +367,59 @@ export class TaskRunner {
       }
       this.tasks.delete(runtimeId);
     }
-    // Also clean JSONL log if taskId is a taskLogId
-    if (taskId.startsWith('task-')) {
-      const logFile = path.join(this.squireDir.logsDir, `${taskId}.jsonl`);
+
+    // Delete JSONL log file
+    const logId = taskId.startsWith('task-') ? taskId : undefined;
+    if (logId) {
+      const logFile = path.join(this.squireDir.logsDir, `${logId}.jsonl`);
       try { if (fs.existsSync(logFile)) fs.unlinkSync(logFile); } catch { /* non-critical */ }
     }
-    this._onTasksChanged.fire();
-    this.squireDir.log('extension', `Task ${taskId} cleaned up`);
-  }
-
-  /** Clean an orphan task: remove its JSONL log, pending decisions, and optionally its worktree */
-  cleanOrphanTask(taskId: string): void {
-    // Delete JSONL log file
-    const logFile = path.join(this.squireDir.logsDir, `${taskId}.jsonl`);
-    try {
-      if (fs.existsSync(logFile)) {
-        fs.unlinkSync(logFile);
-      }
-    } catch { /* non-critical */ }
 
     // Delete any pending decision for this task
     const decisionFile = path.join(this.squireDir.decisionsDir, `${taskId}.json`);
-    try {
-      if (fs.existsSync(decisionFile)) {
-        fs.unlinkSync(decisionFile);
-      }
-    } catch { /* non-critical */ }
+    try { if (fs.existsSync(decisionFile)) fs.unlinkSync(decisionFile); } catch { /* non-critical */ }
 
-    // Try to remove worktree if it exists — extract branch from taskId
-    const issueMatch = taskId.match(/issue-(\d+)/);
-    if (issueMatch) {
-      const branchPatterns = [`dev/issue-${issueMatch[1]}`, `fix/issue-${issueMatch[1]}`, `feat/issue-${issueMatch[1]}`];
-      for (const branch of branchPatterns) {
-        try {
-          this.worktree.remove(this.workspaceRoot, branch);
-        } catch { /* ignore — branch may not exist */ }
+    // If no runtime task was found, try to remove worktree by branch pattern (log-only tasks)
+    if (!found) {
+      const issueMatch = taskId.match(/issue-(\d+)/);
+      if (issueMatch) {
+        const branchPatterns = [`dev/issue-${issueMatch[1]}`, `fix/issue-${issueMatch[1]}`, `feat/issue-${issueMatch[1]}`];
+        for (const branch of branchPatterns) {
+          try { this.worktree.remove(this.workspaceRoot, branch); } catch { /* ignore */ }
+        }
       }
     }
 
     this._onTasksChanged.fire();
-    this.squireDir.log('extension', `Orphan task ${taskId} cleaned up`);
+    this.squireDir.log('extension', `Task ${taskId} cleaned`);
   }
 
+  /** Clean all non-running tasks. Preserves global session index. */
   cleanAll(): void {
+    // Collect non-running task IDs first (avoid mutating while iterating)
+    const toClean: string[] = [];
     for (const [id, task] of this.tasks) {
       if (task.status !== 'running') {
-        if (task.terminal) task.terminal.dispose();
-        this.tasks.delete(id);
+        toClean.push(task.taskLogId || id);
       }
     }
-    // Remove all git worktrees under .squire/worktrees/ properly
+    for (const taskId of toClean) {
+      this.cleanTask(taskId);
+    }
+
+    // Also clean log-only tasks (not in runtime Map) by scanning logs dir
+    try {
+      const logFiles = fs.readdirSync(this.squireDir.logsDir).filter(f => f.endsWith('.jsonl') && f !== 'tasks.jsonl');
+      for (const file of logFiles) {
+        const logId = file.replace('.jsonl', '');
+        // Skip if this task is still running in the Map
+        const found = this.findTask(logId);
+        if (found && found[1].status === 'running') continue;
+        this.cleanTask(logId);
+      }
+    } catch { /* non-critical */ }
+
+    // Remove any remaining worktrees under .squire/worktrees/ (catch stragglers)
     const worktrees = this.worktree.list(this.workspaceRoot);
     const squireWorktreePrefix = path.join(this.workspaceRoot, '.squire', 'worktrees').replace(/\\/g, '/');
     for (const wt of worktrees) {
@@ -399,11 +428,9 @@ export class TaskRunner {
         this.worktree.remove(this.workspaceRoot, wt.branch, true);
       }
     }
-    this.squireDir.log('extension', 'Clean all: removed logs, pending-decisions, worktrees');
-    this.squireDir.cleanDirs();
+
     this._onTasksChanged.fire();
-    // Sync back to main after cleanup
-    this.syncMain();
+    this.squireDir.log('extension', 'Clean all: removed tasks, logs, decisions, worktrees (preserved session index)');
     vscode.window.showInformationMessage('DevSquire: Clean all done.');
   }
 


### PR DESCRIPTION
## Summary

- Replace `killTask`/`cleanupTask`/`cleanOrphanTask` with `stopTask`/`dismissTask`/`cleanTask` for clearer task lifecycle semantics
- Terminal close now marks tasks as `completed` instead of `orphan`; Dismiss hides from dashboard preserving all data; Clean deletes worktree + log + decisions but preserves global session index
- `cleanAll` only affects non-running tasks and no longer calls `cleanDirs()`, preserving `~/.squire/sessions/`

Closes https://github.com/frankliu20/DevSquire/issues/76

## Test plan

- [x] Build passes (`npm run compile`)
- [ ] Manual: stop a running task → verify it shows as completed with Dismiss/Clean buttons
- [ ] Manual: dismiss a completed task → verify it disappears but log files remain on disk
- [ ] Manual: clean a task → verify worktree, log, and decisions are deleted but session index preserved
- [ ] Manual: Clean All → verify only non-running tasks are cleaned, session index intact