### PR TITLE
fix(dashboard): escape single quotes in template literal onclick handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "compile": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap && node scripts/check-webview-syntax.js",
     "watch": "npm run compile -- --watch",
     "lint": "eslint src --ext ts",
     "test": "vitest run",

--- a/scripts/check-webview-syntax.js
+++ b/scripts/check-webview-syntax.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Validates that the compiled dashboard HTML contains syntactically valid JS.
+ * Run after `npm run compile` to catch quote-escaping bugs in template literals.
+ */
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const bundlePath = path.join(__dirname, '..', 'dist', 'extension.js');
+if (!fs.existsSync(bundlePath)) {
+  console.error('ERROR: dist/extension.js not found. Run esbuild first.');
+  process.exit(1);
+}
+
+// Load the bundle with a mock `vscode` module so it doesn't crash
+const code = fs.readFileSync(bundlePath, 'utf-8');
+
+// Extract getDashboardHtml by finding its output in the source.
+// The function concatenates strings into an HTML doc. We can call it
+// by pulling the compiled function out of the bundle.
+//
+// Strategy: regex-extract the full HTML template from the bundle source.
+// The template starts with `<!DOCTYPE html>` and ends with `</html>`.
+// In esbuild's output the template literal is preserved, so we need to
+// evaluate it in a context where the interpolated vars are defined.
+
+// Find the template literal that produces the dashboard HTML
+const tmplMatch = code.match(/return\s*`(<!DOCTYPE html>[\s\S]*?<\/html>)`/);
+if (!tmplMatch) {
+  console.error('ERROR: Could not find dashboard HTML template in bundle');
+  process.exit(1);
+}
+
+// Evaluate the template with dummy values for owner/repo/defaultMode
+let html;
+try {
+  const fn = new Function('owner', 'repo', 'defaultMode', 'return `' + tmplMatch[1] + '`');
+  html = fn('test', 'test', 'auto');
+} catch (e) {
+  console.error('ERROR: Failed to evaluate dashboard HTML template:', e.message);
+  process.exit(1);
+}
+
+const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+if (!scriptMatch) {
+  console.error('ERROR: No <script> tag found in dashboard HTML');
+  process.exit(1);
+}
+
+try {
+  new Function(scriptMatch[1]);
+  console.log('✓ Dashboard webview JS syntax OK');
+} catch (e) {
+  console.error('ERROR: Dashboard webview JS has a syntax error — this will break the entire UI!');
+  console.error(e.message);
+  const lines = scriptMatch[1].split('\n');
+  const lineMatch = e.stack && e.stack.match(/<anonymous>:(\d+)/);
+  if (lineMatch) {
+    const lineNum = parseInt(lineMatch[1]);
+    const start = Math.max(0, lineNum - 3);
+    const end = Math.min(lines.length, lineNum + 2);
+    console.error('\nNear line ' + lineNum + ':');
+    for (let i = start; i < end; i++) {
+      console.error((i === lineNum - 1 ? '>>> ' : '    ') + (i + 1) + ': ' + lines[i]);
+    }
+  }
+  console.error("\nHint: In template literals (backtick strings), use \\\\' not \\' to emit a literal single quote.");
+  process.exit(1);
+}

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -922,7 +922,7 @@ function renderTasks(list) {
   function renderGroup(key, group, prefix) {
     const gid = prefix + '-' + key;
     const isOpen = expandedGroups[gid] !== false; // open by default
-    return '<details class="task-group" ' + (isOpen ? 'open' : '') + ' ontoggle="onGroupToggle(this,\'' + gid + '\')">'
+    return '<details class="task-group" ' + (isOpen ? 'open' : '') + ' ontoggle="onGroupToggle(this,\\'' + gid + '\\')">'
       + '<summary>'
       + '<span class="task-group-title">' + esc(group.label) + '</span>'
       + '<span class="task-group-meta">' + group.tasks.length + ' task' + (group.tasks.length > 1 ? 's' : '') + '</span>'
@@ -1001,7 +1001,7 @@ function renderTaskCard(t) {
     const sessions = t.sessions || [];
     const sessionCount = sessions.length;
     const sessionsHtml = sessionCount > 0
-      ? '<div class="session-toggle" onclick="event.stopPropagation();toggleSessions(\'' + t.id + '\')">'
+      ? '<div class="session-toggle" onclick="event.stopPropagation();toggleSessions(\\'' + t.id + '\\')">'
         + '<span class="chevron ' + (expandedSessions === t.id ? 'open' : '') + '">&#9654;</span>'
         + 'Sessions (' + sessionCount + ')'
         + '</div>'
@@ -1020,7 +1020,7 @@ function renderTaskCard(t) {
               var idStr = s.id ? s.id.slice(0, 12) : '#' + (si + 1);
               var actionBtn = '';
               if (!t.hasTerminal && resumableSession) {
-                actionBtn = '<div class="session-actions"><button class="btn-s btn-sec" onclick="event.stopPropagation();resumeSession(\'' + esc(t.id) + '\',\'' + esc(resumableSession.id) + '\',\'' + esc((t.worktreeDir || '').replace(/\\\\/g, '/')) + '\')">&#9654; Resume</button></div>';
+                actionBtn = '<div class="session-actions"><button class="btn-s btn-sec" onclick="event.stopPropagation();resumeSession(\\'' + esc(t.id) + '\\',\\'' + esc(resumableSession.id) + '\\',\\'' + esc((t.worktreeDir || '').replace(/\\\\/g, '/')) + '\\')">&#9654; Resume</button></div>';
               }
               return '<div class="session-row">'
                 + '<span class="session-source">' + (sourceIcon || '📋') + '</span>'


### PR DESCRIPTION
## Summary
- Fix broken webview JS caused by incorrect single-quote escaping in template literals — `\'` inside backtick strings compiles to bare `'`, breaking onclick handlers (`toggleSessions`, `resumeSession`, `onGroupToggle`) and killing the entire dashboard UI
- Add `scripts/check-webview-syntax.js` as a post-compile gate in `npm run compile` that validates the rendered webview JS is syntactically valid

## Root cause
Commits #82 and #88 added onclick handlers using `\'` to escape single quotes inside a TypeScript template literal. But in backtick strings, `\'` → `'` (the backslash is consumed by the template literal itself). The correct escape is `\'` → `\'`. This caused a JS `SyntaxError` in the webview, preventing any UI from loading.

## Test plan
- [x] `npm run compile` now runs syntax check automatically and passes
- [x] Manually verified extension loads issues, tabs work, sessions toggle works
- [x] Verified the check catches the original bug (reverted fix → compile fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)