### PR TITLE
feat: dashboard UX improvements + move session index to extension

### DIFF
--- a/framework/agents/squire-dev-issue.md
+++ b/framework/agents/squire-dev-issue.md
@@ -62,37 +62,28 @@ Use the `sq.mjs` helper — it handles timestamps, JSON format, and writes to th
 
 ```bash
 # Shorthand: SQ="node $SQUIRE_DIR/bin/sq.mjs"
-# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U] [--session-id $DSQ_SESSION]
+# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
 
 # Run IMMEDIATELY when you start, before any other work:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH"
 # Phase 1 done — issue understood:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH"
 # Phase 2 done — code explored:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH"
 # Phase 3 done — plan approved:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH"
 # Phase 4 done — code written:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH"
 # Phase 5 — tests passed:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH"
 # Phase 5 — tests failed:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH"
 # Phase 6 — PR created:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM
 # Blocked:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH"```
 
-Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM`, `$DSQ_SESSION` with actual values. **Do not skip any of these logs.**
+Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM` with actual values. **Do not skip any of these logs.**
 
 ## Decision Notifications
 
@@ -104,8 +95,7 @@ This applies to: plan approval, clarification questions, test failures, manual v
 
 1. **Create the decision** (one command — writes both the notification file AND the JSONL log entry):
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes"```
 
 2. **Then wait for user input** in the terminal as normal.
 
@@ -191,21 +181,7 @@ Branch name: `fix/adhoc-20260405-143022` or `feat/adhoc-20260405-143022`
 
 **From this point on, all git/build/test commands run inside the worktree directory.**
 
-### Step 3: Initialize Session
-
-Generate a unique session ID and log the session start. This enables multi-session tracking — the dashboard can show session history and the user can resume previous work.
-
-```bash
-# Generate a unique dsq session ID for this run:
-DSQ_SESSION=$(node "$SQUIRE_DIR/bin/sq.mjs" session-id)
-
-# Log session_start as the very first event (before task_start):
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" session_start "New session started" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-```
-
-**All subsequent `sq.mjs log` and `sq.mjs decision` calls MUST include `--session-id "$DSQ_SESSION"`.**
-
-### Step 4: Check Session History
+### Step 3: Check Session History
 
 Check if there are previous sessions for this issue by scanning the JSONL log:
 
@@ -220,8 +196,7 @@ PREV_SESSIONS=$(grep -o '"dsq_session":"[^"]*"' "$SQUIRE_DIR/logs/$TASK_LOG_ID.j
 - Ask: "Continue where the last session left off, or start fresh?"
 - Create a decision notification before prompting:
   ```bash
-  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Resume Session?" "Continue,Start fresh" --session-id "$DSQ_SESSION"
-  ```
+  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Resume Session?" "Continue,Start fresh"  ```
 - After user responds: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
 
 **Auto mode**: Silently continue — no prompt, no decision notification. Resume from the appropriate phase based on previous session state.
@@ -316,8 +291,7 @@ After approval, proceed to Phase 4 with the pre-selected strategy. The user can 
 
 **Otherwise (no `--test-scenario`)**, create a decision notification so the Dashboard can alert the user:
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes"```
 Then prompt:
 
 ```
@@ -379,7 +353,7 @@ If the file does not exist or a field is missing, auto-detect from project files
 - Run build + impacted tests (same as strategy 2)
 - If either fails: auto-fix up to 3 rounds
 - All pass → prepare the manual verify environment and STOP:
-  - Create a decision: `node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues" --session-id "$DSQ_SESSION"`
+  - Create a decision: `node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues"`
   - Wait for user to reply "ok" or describe issues to fix.
   - After user responds: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
 

--- a/framework/commands/claude/squire-dev-issue.md
+++ b/framework/commands/claude/squire-dev-issue.md
@@ -53,37 +53,28 @@ All operations use `gh` CLI (GitHub only).
 Use the `sq.mjs` helper — it handles timestamps, JSON format, and writes to the correct path regardless of your current directory:
 
 ```bash
-# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U] [--session-id $DSQ_SESSION]
+# All commands use: node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" <event-type> <detail> [--branch X] [--pr N] [--pr-url U]
 
 # Run IMMEDIATELY when you start, before any other work:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" task_start "Starting issue analysis" --branch "$BRANCH"
 # After issue analysis:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" analysis_done "Issue analyzed" --branch "$BRANCH"
 # After code exploration:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" exploration_done "Code explored" --branch "$BRANCH"
 # After plan approved:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" plan_approved "Plan approved" --branch "$BRANCH"
 # After implementation:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" implementation_done "Implementation complete" --branch "$BRANCH"
 # Tests passed:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_pass "Tests passed" --branch "$BRANCH"
 # Tests failed:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" test_fail "<error summary>" --branch "$BRANCH"
 # PR created:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM --session-id "$DSQ_SESSION"
-
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" pr_created "PR created" --branch "$BRANCH" --pr $PR_NUM
 # Blocked:
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" blocked "<reason>" --branch "$BRANCH"```
 
-Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM`, `$DSQ_SESSION` with actual values. **Do not skip any of these logs.**
+Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM` with actual values. **Do not skip any of these logs.**
 
 ## Decision Notifications
 
@@ -91,8 +82,7 @@ Replace `$TASK_LOG_ID`, `$SQUIRE_DIR`, `$BRANCH`, `$PR_NUM`, `$DSQ_SESSION` with
 
 1. **Create the decision** (one command — writes both the notification file AND the JSONL log entry):
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval for Issue #N" "Approve,Request changes"```
 
 2. **Then wait for user input** in the terminal as normal.
 
@@ -152,20 +142,6 @@ Create the feature branch:
 git checkout -b fix/issue-<N>  # or feat/issue-<N> for features
 ```
 
-### Initialize Session
-
-Generate a unique session ID and log the session start. This enables multi-session tracking — the dashboard can show session history and the user can resume previous work.
-
-```bash
-# Generate a unique dsq session ID for this run:
-DSQ_SESSION=$(node "$SQUIRE_DIR/bin/sq.mjs" session-id)
-
-# Log session_start as the very first event (before task_start):
-node "$SQUIRE_DIR/bin/sq.mjs" log "$SQUIRE_DIR" "$TASK_LOG_ID" session_start "New session started" --branch "$BRANCH" --session-id "$DSQ_SESSION"
-```
-
-**All subsequent `sq.mjs log` and `sq.mjs decision` calls MUST include `--session-id "$DSQ_SESSION"`.**
-
 ### Check Session History
 
 Check if there are previous sessions for this issue by scanning the JSONL log:
@@ -181,8 +157,7 @@ PREV_SESSIONS=$(grep -o '"dsq_session":"[^"]*"' "$SQUIRE_DIR/logs/$TASK_LOG_ID.j
 - Ask: "Continue where the last session left off, or start fresh?"
 - Create a decision notification before prompting:
   ```bash
-  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Resume Session?" "Continue,Start fresh" --session-id "$DSQ_SESSION"
-  ```
+  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Resume Session?" "Continue,Start fresh"  ```
 - After user responds: `node "$SQUIRE_DIR/bin/sq.mjs" decision-clear "$SQUIRE_DIR" "$TASK_LOG_ID"`
 
 **Auto mode**: Silently continue — no prompt, no decision notification.
@@ -259,8 +234,7 @@ Based on exploration, create a plan:
 
 **Otherwise**, create a decision notification, then prompt:
 ```bash
-node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes" --session-id "$DSQ_SESSION"
-```
+node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Plan Approval" "Approve,Request changes"```
 Then show:
 ```
 Plan is ready. How should we verify the changes?
@@ -314,8 +288,7 @@ If not found, auto-detect from project files (`package.json`, `pom.xml`, `Makefi
 - Failures → auto-fix up to 3 rounds
 - All pass → create decision notification and wait for user "ok":
   ```bash
-  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues" --session-id "$DSQ_SESSION"
-  ```
+  node "$SQUIRE_DIR/bin/sq.mjs" decision "$SQUIRE_DIR" "$TASK_LOG_ID" "Manual Verify" "OK,Has issues"  ```
 
 **If auto-fix fails after 3 rounds**: STOP and report. **Auto mode**: log `blocked` and stop.
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "properties": {
         "devSquire.aiPlatform": {
           "type": "string",
-          "default": "copilot-cli",
+          "default": "claude-code",
           "enum": [
             "copilot-cli",
             "claude-code"

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -364,6 +364,21 @@ input:focus { outline: none; border-color: var(--focus); box-shadow: 0 0 0 1px v
 .session-status.ended { color: var(--fg-muted); }
 .session-actions { margin-left: auto; flex-shrink: 0; }
 
+/* ===== Historical sessions ===== */
+.history-header {
+  display: flex; align-items: center; gap: var(--sp-2); margin-top: var(--sp-4);
+  padding-bottom: var(--sp-1); border-bottom: 1px solid var(--border-subtle);
+  color: var(--fg-muted); font-size: var(--text-xs);
+}
+.history-card {
+  border: 1px dashed var(--border-subtle); border-radius: var(--r-md);
+  padding: var(--sp-2) var(--sp-3); margin-top: var(--sp-2);
+  background: var(--bg-surface); opacity: 0.85;
+}
+.history-card:hover { opacity: 1; border-color: var(--fg-muted); }
+.history-card .task-label { color: var(--fg); }
+.history-card .task-meta { font-size: var(--text-xs); color: var(--fg-muted); margin-top: var(--sp-1); }
+
 /* ===== Action card ===== */
 .action-card {
   border: 1px solid var(--border-subtle); border-radius: var(--r-md);
@@ -561,8 +576,10 @@ input:focus { outline: none; border-color: var(--focus); box-shadow: 0 0 0 1px v
   <div class="pad">
     <div class="row mb8">
       <button class="btn-s btn-sec" onclick="refreshTasks()">↻ Refresh</button>
+      <button class="btn-s btn-sec" onclick="loadHistory()" id="historyBtn">📂 History</button>
     </div>
     <div id="taskList"><div class="empty" data-icon="⚙️">No active tasks</div></div>
+    <div id="historyList"></div>
   </div>
 </div>
 
@@ -629,6 +646,7 @@ let issues = [], prs = { mine: [], review: [] }, tasks = [], decisions = [], ski
 let currentTab = 'issues', prFilter = 'mine', reportView = 'eod', skillFilter = 'all';
 let expandedIssue = null, expandedTask = null, expandedSkill = null, expandedPR = null, expandedSessions = null;
 let expandedGroups = {}; // track collapsed groups
+let historyTasks = [];
 let confirmCallback = null;
 let issuesLoaded = false, prsLoaded = false;
 let myPRSubFilter = 'all'; // 'all' | 'ready'
@@ -863,6 +881,10 @@ function badgeFor(action) {
 
 // ===== Tasks =====
 function refreshTasks() { vscode.postMessage({ type: 'getTasks' }); }
+function loadHistory() {
+  document.getElementById('historyBtn').textContent = '📂 Loading...';
+  vscode.postMessage({ type: 'loadHistory' });
+}
 const PHASES = ['planned','analyzing','exploring','planning','implementing','testing','creating_pr','done'];
 const PHASE_LABELS = { planned: 'Planned', analyzing: 'Analyzing', exploring: 'Exploring', planning: 'Planning', implementing: 'Implementing', testing: 'Testing', creating_pr: 'Creating PR', done: 'Done', reviewing: 'Reviewing', reviewed: 'Reviewed', published: 'Published', monitoring: 'Monitor', fixing_ci: 'Fix CI', fixing_comments: 'Fix Comments' };
 // Map internal phases to pipeline display phases
@@ -952,7 +974,13 @@ function renderTasks(list) {
     if (sortedIssues.length || sortedPRs.length) {
       html += '<div class="task-section-header"><span class="section-icon">📦</span> Adhoc</div>';
     }
-    html += otherTasks.map(renderTaskCard).join('');
+    // Wrap adhoc tasks in a collapsible group
+    var adhocOpen = expandedGroups['adhoc'] !== false;
+    html += '<details class="task-group" ' + (adhocOpen ? 'open' : '') + ' ontoggle="onGroupToggle(this,\\'adhoc\\')">'
+      + '<summary><span class="task-group-title">Adhoc Tasks</span><span class="task-group-meta">' + otherTasks.length + ' task' + (otherTasks.length > 1 ? 's' : '') + '</span>'
+      + groupStatusBadge(otherTasks) + '</summary>'
+      + '<div class="task-group-cards">' + otherTasks.map(function(t) { t._inGroup = true; return renderTaskCard(t); }).join('') + '</div>'
+      + '</details>';
   }
 
   c.innerHTML = html;
@@ -1058,6 +1086,27 @@ function renderTaskCard(t) {
       if (resumable) break;
     }
 
+    // ===== Action buttons (logic separated from display) =====
+    var isLive = t.hasTerminal && t.status === 'running';   // agent actively running in a terminal
+    var isStopped = !t.hasTerminal;                          // no terminal — stopped, closed, or log-only
+    var isDone = t.phase === 'done' || t.phase === 'failed';
+    var canResume = isStopped && !!resumable;
+    var canRerun = isStopped && !resumable && !!t.issueUrl && !isDone;
+    var canDismiss = !isLive;
+    var canClean = !isLive;
+    var canStop = isLive;
+    var canFocus = !!t.hasTerminal;
+    var canWorktree = !!t.worktreeDir && isLive;
+
+    var actions = [];
+    if (canFocus)    actions.push('<button class="btn btn-pri" onclick="event.stopPropagation();focusTerminal(\\''+t.id+'\\')">Terminal</button>');
+    if (canWorktree) actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>');
+    if (canDismiss)  actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')\" title=\"Hide from dashboard (keeps worktree and logs)\">Dismiss</button>');
+    if (canClean)    actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))\" title=\"Remove worktree, branch, and logs permanently\">Clean</button>');
+    if (canResume)   actions.push('<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();resumeSession(\\''+t.id+'\\',\\''+resumable.id+'\\',\\''+(t.worktreeDir||'').replace(/\\\\/g,'/')+'\\')">▶ Resume</button>');
+    if (canRerun)    actions.push('<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();rerunIssue(\\''+esc(t.issueUrl)+'\\',\\''+esc(t.label || '')+'\\')">▶ Re-run</button>');
+    if (canStop)     actions.push('<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>');
+
     return \`
     <div class="task-card \${phaseClass}" onclick="toggleTaskEvents('\${t.id}')">
       <div class="task-header">
@@ -1069,14 +1118,7 @@ function renderTaskCard(t) {
         \${t.branch ? t.branch + ' · ' : ''}\${t.prNumber ? 'PR #' + t.prNumber + ' · ' : ''}\${shortTime(t.startedAt)}
         \${t.status === 'running' ? ' · ' + duration(t.startedAt) : ''}
       </div>
-      <div class="task-actions">
-        \${t.hasTerminal ? '<button class="btn btn-pri" onclick="event.stopPropagation();focusTerminal(\\''+t.id+'\\')">Terminal</button>' : ''}
-        \${t.worktreeDir && t.status === 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>' : ''}
-        \${!t.hasTerminal || t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')\" title=\"Hide from dashboard (keeps worktree and logs)\">Dismiss</button>' : ''}
-        \${!t.hasTerminal || t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))\" title=\"Remove worktree, branch, and logs permanently\">Clean</button>' : ''}
-        \${!t.hasTerminal && resumable ? '<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();resumeSession(\\''+t.id+'\\',\\''+resumable.id+'\\',\\''+(t.worktreeDir||'').replace(/\\\\/g,'/')+'\\')">▶ Resume</button>' : ''}
-        \${t.status === 'running' && t.hasTerminal ? '<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal and mark completed.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>' : ''}
-      </div>
+      <div class="task-actions">\${actions.join('')}</div>
       \${eventsHtml}
       \${sessionsHtml}
     </div>\`;
@@ -1085,6 +1127,30 @@ function toggleTaskEvents(id) { expandedTask = expandedTask === id ? null : id; 
 function stopTask(id) { vscode.postMessage({ type: 'stopTask', taskId: id }); }
 function dismissTask(id) { vscode.postMessage({ type: 'dismissTask', taskId: id }); }
 function cleanupTask(id) { vscode.postMessage({ type: 'cleanupTask', taskId: id }); }
+
+function renderHistory(list) {
+  var c = document.getElementById('historyList');
+  document.getElementById('historyBtn').textContent = '📂 History';
+  if (!list.length) { c.innerHTML = ''; return; }
+  // Filter out tasks already shown in active tasks
+  var activeIds = new Set(tasks.map(function(t) { return t.taskLogId || t.id; }));
+  var filtered = list.filter(function(h) { return !activeIds.has(h.taskLogId); });
+  if (!filtered.length) { c.innerHTML = '<div class="empty" data-icon="📂">No previous sessions for open issues</div>'; return; }
+  var html = '<div class="history-header"><span>🕐</span> Previous Sessions (open issues)</div>';
+  html += filtered.map(function(h) {
+    var resumeBtn = '';
+    if (h.resumableSessionId) {
+      resumeBtn = '<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();resumeSession(\\'' + esc(h.taskLogId) + '\\',\\'' + esc(h.resumableSessionId) + '\\',\\'' + esc(h.worktreeDir || '') + '\\')">▶ Resume</button>';
+    }
+    return '<div class="history-card">'
+      + '<div class="task-header"><span class="task-label">' + esc(h.label) + '</span></div>'
+      + '<div class="task-meta">' + (h.lastSessionTime ? shortTime(h.lastSessionTime) : '') + ' · ' + h.sessionCount + ' session' + (h.sessionCount > 1 ? 's' : '') + '</div>'
+      + '<div class="task-actions">' + resumeBtn + '</div>'
+      + '</div>';
+  }).join('');
+  c.innerHTML = html;
+}
+
 function cleanAll() { vscode.postMessage({ type: 'cleanAll' }); }
 function syncMain() { vscode.postMessage({ type: 'syncMain' }); }
 function offWork() {
@@ -1124,6 +1190,7 @@ function openWorktree(id, dir) { vscode.postMessage({ type: 'openWorktree', task
 function focusTerminal(id) { vscode.postMessage({ type: 'focusTerminal', taskId: id }); }
 function toggleSessions(id) { expandedSessions = expandedSessions === id ? null : id; renderTasks(tasks); }
 function resumeSession(taskId, aiSessionId, worktreeDir) { vscode.postMessage({ type: 'resumeSession', taskId: taskId, aiSessionId: aiSessionId, worktreeDir: worktreeDir }); }
+function rerunIssue(issueUrl, title) { vscode.postMessage({ type: 'devIssue', issueUrl: issueUrl, mode: 'auto', title: title }); }
 
 // ===== Actions (Decisions) =====
 function renderDecisions(list) {
@@ -1349,6 +1416,10 @@ window.addEventListener('message', e => {
       document.getElementById('statTasks').textContent = tasks.filter(t => t.status === 'running').length;
       renderTasks(tasks);
       if (issuesLoaded) filterIssues(); // refresh issue phase badges
+      break;
+    case 'historySessions':
+      historyTasks = msg.data || [];
+      renderHistory(historyTasks);
       break;
     case 'decisions':
       decisions = msg.data;

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -1041,7 +1041,6 @@ function renderTaskCard(t) {
     // When inside a group, show "Session <id> [Claude/Copilot]" instead of the full label
     var displayLabel = t.label || 'Task ' + t.id;
     if (t._inGroup) {
-      var sessions = t.sessions || [];
       var aiSource = '';
       for (var si = 0; si < sessions.length; si++) {
         var ais = sessions[si].aiSessions;
@@ -1053,9 +1052,8 @@ function renderTaskCard(t) {
 
     // Find resumable session for showing Resume button on task card
     var resumable = null;
-    var taskSessions = t.sessions || [];
-    for (var ri = taskSessions.length - 1; ri >= 0; ri--) {
-      var rais = taskSessions[ri].aiSessions;
+    for (var ri = sessions.length - 1; ri >= 0; ri--) {
+      var rais = sessions[ri].aiSessions;
       if (rais) { for (var rai = 0; rai < rais.length; rai++) { if (rais[rai].resumable) { resumable = rais[rai]; break; } } }
       if (resumable) break;
     }

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -1101,8 +1101,8 @@ function renderTaskCard(t) {
     var actions = [];
     if (canFocus)    actions.push('<button class="btn btn-pri" onclick="event.stopPropagation();focusTerminal(\\''+t.id+'\\')">Terminal</button>');
     if (canWorktree) actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>');
-    if (canDismiss)  actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')\" title=\"Hide from dashboard (keeps worktree and logs)\">Dismiss</button>');
-    if (canClean)    actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))\" title=\"Remove worktree, branch, and logs permanently\">Clean</button>');
+    if (canDismiss)  actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')" title="Hide from dashboard (keeps worktree and logs)">Dismiss</button>');
+    if (canClean)    actions.push('<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))" title="Remove worktree, branch, and logs permanently">Clean</button>');
     if (canResume)   actions.push('<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();resumeSession(\\''+t.id+'\\',\\''+resumable.id+'\\',\\''+(t.worktreeDir||'').replace(/\\\\/g,'/')+'\\')">▶ Resume</button>');
     if (canRerun)    actions.push('<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();rerunIssue(\\''+esc(t.issueUrl)+'\\',\\''+esc(t.label || '')+'\\')">▶ Re-run</button>');
     if (canStop)     actions.push('<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>');

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -881,7 +881,7 @@ function renderTasks(list) {
   const c = document.getElementById('taskList');
   if (!list.length) { c.innerHTML = '<div class="empty" data-icon="⚙️">No active tasks</div>'; return; }
 
-  // Categorize tasks into Issues, PRs, Other
+  // Categorize tasks into Issues, PRs, Adhoc
   const PR_TYPES = { 'review-pr': 1, 'watch-pr': 1, 'fix-comments': 1 };
   const issueGroups = {};  // issueNumber → { tasks, label }
   const prGroups = {};     // prNumber → { tasks, label }
@@ -893,7 +893,11 @@ function renderTasks(list) {
       if (!prGroups[t.prNumber]) prGroups[t.prNumber] = { tasks: [], label: t.label || 'PR #' + t.prNumber };
       prGroups[t.prNumber].tasks.push(t);
     } else if (issueNum) {
-      if (!issueGroups[issueNum]) issueGroups[issueNum] = { tasks: [], label: t.label || 'Issue #' + issueNum };
+      if (!issueGroups[issueNum]) {
+        // Extract description from label like "[Normal] Dev #42 Fix login bug" → "Fix login bug"
+        var desc = (t.label || '').replace(/^\[.*?\]\s*/, '').replace(/^Dev\s*#\d+\s*/, '');
+        issueGroups[issueNum] = { tasks: [], label: 'Issue #' + issueNum + (desc ? ' ' + desc : '') };
+      }
       issueGroups[issueNum].tasks.push(t);
     } else {
       otherTasks.push(t);
@@ -928,7 +932,7 @@ function renderTasks(list) {
       + '<span class="task-group-meta">' + group.tasks.length + ' task' + (group.tasks.length > 1 ? 's' : '') + '</span>'
       + groupStatusBadge(group.tasks)
       + '</summary>'
-      + '<div class="task-group-cards">' + group.tasks.map(renderTaskCard).join('') + '</div>'
+      + '<div class="task-group-cards">' + group.tasks.map(function(t) { t._inGroup = true; return renderTaskCard(t); }).join('') + '</div>'
       + '</details>';
   }
 
@@ -946,7 +950,7 @@ function renderTasks(list) {
   }
   if (otherTasks.length) {
     if (sortedIssues.length || sortedPRs.length) {
-      html += '<div class="task-section-header"><span class="section-icon">📦</span> Other</div>';
+      html += '<div class="task-section-header"><span class="section-icon">📦</span> Adhoc</div>';
     }
     html += otherTasks.map(renderTaskCard).join('');
   }
@@ -1034,10 +1038,32 @@ function renderTaskCard(t) {
           : '')
       : '';
 
+    // When inside a group, show "Session <id> [Claude/Copilot]" instead of the full label
+    var displayLabel = t.label || 'Task ' + t.id;
+    if (t._inGroup) {
+      var sessions = t.sessions || [];
+      var aiSource = '';
+      for (var si = 0; si < sessions.length; si++) {
+        var ais = sessions[si].aiSessions;
+        if (ais && ais.length) { aiSource = ais[0].source === 'claude' ? 'Claude' : 'Copilot'; break; }
+      }
+      var sessId = sessions.length && sessions[sessions.length - 1].id ? sessions[sessions.length - 1].id.slice(0, 12) : t.id.slice(0, 12);
+      displayLabel = 'Session ' + sessId + (aiSource ? ' [' + aiSource + ']' : '');
+    }
+
+    // Find resumable session for showing Resume button on task card
+    var resumable = null;
+    var taskSessions = t.sessions || [];
+    for (var ri = taskSessions.length - 1; ri >= 0; ri--) {
+      var rais = taskSessions[ri].aiSessions;
+      if (rais) { for (var rai = 0; rai < rais.length; rai++) { if (rais[rai].resumable) { resumable = rais[rai]; break; } } }
+      if (resumable) break;
+    }
+
     return \`
     <div class="task-card \${phaseClass}" onclick="toggleTaskEvents('\${t.id}')">
       <div class="task-header">
-        <span class="task-label">\${esc(t.label || 'Task ' + t.id)}</span>
+        <span class="task-label">\${esc(displayLabel)}</span>
         <span class="badge \${badgeClass}">\${esc(latestStatus)}</span>
       </div>
       \${isCyclic || isChat ? '' : '<div class="pipeline">' + pipeline + '</div>'}
@@ -1047,10 +1073,11 @@ function renderTaskCard(t) {
       </div>
       <div class="task-actions">
         \${t.hasTerminal ? '<button class="btn btn-pri" onclick="event.stopPropagation();focusTerminal(\\''+t.id+'\\')">Terminal</button>' : ''}
-        \${t.worktreeDir ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>' : ''}
-        \${t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')">Dismiss</button>' : ''}
-        \${t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))">Clean</button>' : ''}
-        \${t.status === 'running' ? '<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal and mark completed.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>' : ''}
+        \${t.worktreeDir && t.status === 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();openWorktree(\\''+t.id+'\\',\\''+t.worktreeDir.replace(/\\\\/g,'/')+'\\')">Worktree</button>' : ''}
+        \${!t.hasTerminal || t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();dismissTask(\\''+t.id+'\\')\" title=\"Hide from dashboard (keeps worktree and logs)\">Dismiss</button>' : ''}
+        \${!t.hasTerminal || t.status !== 'running' ? '<button class="btn-s btn-sec" onclick="event.stopPropagation();confirmAction(\\'Clean up?\\',\\'Remove worktree and logs.\\',()=>cleanupTask(\\''+t.id+'\\'))\" title=\"Remove worktree, branch, and logs permanently\">Clean</button>' : ''}
+        \${!t.hasTerminal && resumable ? '<button class="btn btn-pri" style="margin-left:auto" onclick="event.stopPropagation();resumeSession(\\''+t.id+'\\',\\''+resumable.id+'\\',\\''+(t.worktreeDir||'').replace(/\\\\/g,'/')+'\\')">▶ Resume</button>' : ''}
+        \${t.status === 'running' && t.hasTerminal ? '<button class="btn-s btn-danger" style="margin-left:auto" onclick="event.stopPropagation();confirmAction(\\'Stop task?\\',\\'Close the terminal and mark completed.\\',()=>stopTask(\\''+t.id+'\\'))">Stop</button>' : ''}
       </div>
       \${eventsHtml}
       \${sessionsHtml}

--- a/src/dashboard-provider.ts
+++ b/src/dashboard-provider.ts
@@ -10,6 +10,7 @@ import { TaskStateReader, defaultRunningPhase } from './task-state';
 import { SkillsReader } from './skills-reader';
 import { ReportGenerator } from './report';
 import { getDashboardHtml } from './dashboard-html';
+import { SessionIndexManager } from './session-index-manager';
 
 /** A single session entry from the global session index */
 export interface SessionEntry {
@@ -33,6 +34,7 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
     private readonly taskStateReader: TaskStateReader,
     private readonly skillsReader: SkillsReader,
     private readonly reportGenerator: ReportGenerator,
+    private readonly sessionIndexManager: SessionIndexManager,
   ) {
     this.taskRunner.onTasksChanged(() => this.sendTasks());
   }
@@ -66,9 +68,8 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
   private setupFileWatchers(): void {
     const logsDir = this.squireDir.logsDir;
     const decisionsDir = this.squireDir.decisionsDir;
-    const sessionsDir = path.join(os.homedir(), '.squire', 'sessions');
 
-    for (const dir of [logsDir, decisionsDir, sessionsDir]) {
+    for (const dir of [logsDir, decisionsDir]) {
       try {
         if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
         const watcher = fs.watch(dir, () => {
@@ -169,6 +170,10 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
         this.sendTasks();
         break;
       }
+      case 'loadHistory': {
+        setImmediate(() => this.sendHistorySessions());
+        break;
+      }
       case 'cleanupTask': {
         this.taskRunner.cleanTask(msg.taskId);
         this.sendTasks();
@@ -192,15 +197,7 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
         break;
       }
       case 'resumeSession': {
-        // Resume a Claude AI session in a new terminal: claude --resume <aiSessionId>
-        const resumeCwd = msg.worktreeDir || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-        const resumeTerminal = vscode.window.createTerminal({
-          name: `Resume: ${msg.aiSessionId?.slice(0, 8) || 'session'}`,
-          cwd: resumeCwd,
-          iconPath: new vscode.ThemeIcon('debug-restart'),
-        });
-        resumeTerminal.show(false);
-        resumeTerminal.sendText(`claude --resume "${msg.aiSessionId}"`, true);
+        this.taskRunner.resumeSession(msg.taskId, msg.aiSessionId, msg.worktreeDir);
         break;
       }
 
@@ -330,8 +327,11 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
       if (!claimedLogIds.has(lt.id) && !merged.find((m) => m.id === lt.id)) {
         merged.push({
           id: lt.id,
-          label: lt.issueNumber ? `Issue #${lt.issueNumber}` : lt.id,
-          type: 'dev-issue' as const,
+          label: lt.issueNumber ? `Issue #${lt.issueNumber}` : lt.prNumber ? `PR #${lt.prNumber}` : lt.id,
+          type: (lt.id.startsWith('task-review-') ? 'review-pr'
+            : lt.id.startsWith('task-fix-') ? 'fix-comments'
+            : lt.id.startsWith('task-watch-') ? 'watch-pr'
+            : 'dev-issue') as const,
           status: lt.phase === 'done' ? 'completed' as const : lt.phase === 'failed' ? 'failed' as const : 'completed' as const,
           phase: lt.phase,
           branch: lt.branch,
@@ -354,20 +354,16 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Read the global session index (~/.squire/sessions/index.json)
+   * Read the global session index via SessionIndexManager
    * and return a map of taskLogId → SessionEntry[] for the current repo.
    */
   private readGlobalSessionIndex(): Record<string, SessionEntry[]> {
-    const indexPath = path.join(os.homedir(), '.squire', 'sessions', 'index.json');
     try {
-      if (!fs.existsSync(indexPath)) return {};
-      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-      const repoSlug = this.repoInfo.slug;
-      const repoEntry = index[repoSlug];
-      if (!repoEntry) return {};
+      const repoSlug = `${this.repoInfo.owner}/${this.repoInfo.repo}`;
+      const repoData = this.sessionIndexManager.readRepoSessions(repoSlug);
       const result: Record<string, SessionEntry[]> = {};
-      for (const [taskLogId, taskEntry] of Object.entries(repoEntry)) {
-        const sessions = (taskEntry as any)?.sessions;
+      for (const [taskLogId, taskEntry] of Object.entries(repoData)) {
+        const sessions = taskEntry?.sessions;
         if (Array.isArray(sessions) && sessions.length > 0) {
           result[taskLogId] = sessions;
         }
@@ -375,6 +371,79 @@ export class DashboardViewProvider implements vscode.WebviewViewProvider {
       return result;
     } catch {
       return {};
+    }
+  }
+
+  /**
+   * Load historical sessions for open issues from the global session index.
+   * Returns session summaries filtered to only issues that are currently open.
+   */
+  private sendHistorySessions(): void {
+    try {
+      const repoSlug = `${this.repoInfo.owner}/${this.repoInfo.repo}`;
+      const repoEntry = this.sessionIndexManager.readRepoSessions(repoSlug);
+      if (!Object.keys(repoEntry).length) {
+        this.post('historySessions', []);
+        return;
+      }
+
+      // Get open issues to filter against
+      const openIssues = this.ghData.listMyIssues();
+      const openIssueNums = new Set(openIssues.map((i: any) => i.number));
+
+      const results: Array<{
+        taskLogId: string;
+        issueNumber: number;
+        label: string;
+        sessionCount: number;
+        lastSessionTime: string;
+        resumableSessionId: string | null;
+        worktreeDir: string;
+      }> = [];
+
+      for (const [taskLogId, taskEntry] of Object.entries(repoEntry)) {
+        // Extract issue number from taskLogId like "task-issue-38"
+        const issueMatch = taskLogId.match(/task-issue-(\d+)/);
+        if (!issueMatch) continue;
+        const issueNum = parseInt(issueMatch[1]);
+        if (!openIssueNums.has(issueNum)) continue;
+
+        const sessions = (taskEntry as any)?.sessions;
+        if (!Array.isArray(sessions) || sessions.length === 0) continue;
+
+        // Find the matching open issue for the label
+        const issue = openIssues.find((i: any) => i.number === issueNum);
+        const label = issue ? `Issue #${issueNum} ${issue.title}` : `Issue #${issueNum}`;
+
+        // Find last resumable AI session
+        let resumableSessionId: string | null = null;
+        for (let i = sessions.length - 1; i >= 0; i--) {
+          const aiSessions = sessions[i].aiSessions;
+          if (aiSessions) {
+            for (const ai of aiSessions) {
+              if (ai.resumable) { resumableSessionId = ai.id; break; }
+            }
+          }
+          if (resumableSessionId) break;
+        }
+
+        const lastSession = sessions[sessions.length - 1];
+        results.push({
+          taskLogId,
+          issueNumber: issueNum,
+          label,
+          sessionCount: sessions.length,
+          lastSessionTime: lastSession.endedAt || lastSession.startedAt || '',
+          resumableSessionId,
+          worktreeDir: '',
+        });
+      }
+
+      // Sort by last session time, newest first
+      results.sort((a, b) => b.lastSessionTime.localeCompare(a.lastSessionTime));
+      this.post('historySessions', results);
+    } catch {
+      this.post('historySessions', []);
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
   squireDir.ensureGitignore();
 
   // Create backend from user setting
-  const backendType = vscode.workspace.getConfiguration('devSquire').get<BackendType>('aiPlatform', 'copilot-cli');
+  const backendType = vscode.workspace.getConfiguration('devSquire').get<BackendType>('aiPlatform', 'claude-code');
   const backend = createBackend(backendType);
   squireDir.log('extension', `Backend: ${backend.type}`);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { GitHubData } from './github-data';
 import { TaskStateReader } from './task-state';
 import { SkillsReader } from './skills-reader';
 import { ReportGenerator } from './report';
+import { SessionIndexManager } from './session-index-manager';
 
 let dashboardProvider: DashboardViewProvider;
 
@@ -42,6 +43,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const ghData = new GitHubData(repoInfo.owner, repoInfo.repo);
   const worktree = new WorktreeManager();
   const taskRunner = new TaskRunner(worktree, workspaceRoot, repoInfo, squireDir, backend);
+
+  // Session index manager — listens to task lifecycle events and maintains ~/.squire/sessions/index.json
+  const sessionIndexManager = new SessionIndexManager();
+  taskRunner.onSessionEvent((event) => sessionIndexManager.handleEvent(event));
+
   const taskStateReader = new TaskStateReader(squireDir.dir);
   const skillsReader = new SkillsReader(backend);
   const reportGenerator = new ReportGenerator(ghData, squireDir.dir, workspaceRoot, repoInfo.owner, repoInfo.repo);
@@ -55,6 +61,7 @@ export async function activate(context: vscode.ExtensionContext) {
     taskStateReader,
     skillsReader,
     reportGenerator,
+    sessionIndexManager,
   );
 
   context.subscriptions.push(

--- a/src/session-detector.ts
+++ b/src/session-detector.ts
@@ -50,24 +50,33 @@ export function copilotEventsMatchTaskLogId(content: string, taskLogId: string):
 }
 
 /**
- * Detect Claude AI sessions by scanning ~/.claude/sessions/*.json
- * and matching by working directory.
+ * Detect Claude AI sessions by scanning ~/.claude/projects/<encoded-cwd>/
+ * for session JSONL files. The filename (minus .jsonl) is the session ID.
+ *
+ * Claude encodes the cwd into a directory name by replacing : \ / . with -
  */
 export function detectClaudeSession(cwd: string): AiSession | null {
-  const sessionsDir = path.join(os.homedir(), '.claude', 'sessions');
   try {
-    if (!fs.existsSync(sessionsDir)) return null;
-    const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith('.json'));
+    const encodedCwd = cwd.replace(/[:\\/\.]/g, '-');
+    const projectDir = path.join(os.homedir(), '.claude', 'projects', encodedCwd);
+    if (!fs.existsSync(projectDir)) return null;
 
-    // Check files newest-first (highest PID or newest mtime likely most relevant)
-    for (const file of files.reverse()) {
-      const content = fs.readFileSync(path.join(sessionsDir, file), 'utf-8');
-      const sessionId = parseClaudeSessionFile(content, cwd);
-      if (sessionId) {
-        return { source: 'claude', id: sessionId, resumable: true };
+    const jsonlFiles = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
+    if (jsonlFiles.length === 0) return null;
+
+    // Pick the most recently modified .jsonl — that's the latest session
+    let bestFile = '';
+    let bestMtime = 0;
+    for (const file of jsonlFiles) {
+      const stat = fs.statSync(path.join(projectDir, file));
+      if (stat.mtimeMs > bestMtime) {
+        bestMtime = stat.mtimeMs;
+        bestFile = file;
       }
     }
-    return null;
+
+    const sessionId = bestFile.replace('.jsonl', '');
+    return { source: 'claude', id: sessionId, resumable: true };
   } catch {
     return null;
   }

--- a/src/session-detector.ts
+++ b/src/session-detector.ts
@@ -9,23 +9,12 @@ export interface AiSession {
 }
 
 /**
- * Parse a Claude session JSON file and return the sessionId if it matches the given cwd.
+ * Check if file content contains the given taskLogId (via [task-log-id:...] tag).
+ * Used by both Claude and Copilot detectors.
  * Exported for testing.
  */
-export function parseClaudeSessionFile(content: string, cwd: string): string | null {
-  try {
-    const data = JSON.parse(content);
-    if (!data.sessionId || !data.cwd) return null;
-    // Normalize paths for comparison (handle Windows vs Unix)
-    const normalizedCwd = cwd.replace(/\\/g, '/').toLowerCase();
-    const normalizedSessionCwd = String(data.cwd).replace(/\\/g, '/').toLowerCase();
-    if (normalizedSessionCwd === normalizedCwd) {
-      return data.sessionId;
-    }
-    return null;
-  } catch {
-    return null;
-  }
+export function contentMatchesTaskLogId(content: string, taskLogId: string): boolean {
+  return content.includes(taskLogId);
 }
 
 /**
@@ -33,7 +22,6 @@ export function parseClaudeSessionFile(content: string, cwd: string): string | n
  * Exported for testing.
  */
 export function parseCopilotWorkspaceYaml(content: string): string | null {
-  // Simple YAML parsing — extract `id:` field from top level
   for (const line of content.split('\n')) {
     const match = line.match(/^id:\s*(.+)$/);
     if (match) return match[1].trim();
@@ -42,20 +30,13 @@ export function parseCopilotWorkspaceYaml(content: string): string | null {
 }
 
 /**
- * Check if a Copilot events.jsonl contains a reference to the given taskLogId.
- * Exported for testing.
- */
-export function copilotEventsMatchTaskLogId(content: string, taskLogId: string): boolean {
-  return content.includes(taskLogId);
-}
-
-/**
- * Detect Claude AI sessions by scanning ~/.claude/projects/<encoded-cwd>/
- * for session JSONL files. The filename (minus .jsonl) is the session ID.
+ * Detect Claude AI sessions by scanning ~/.claude/projects/<encoded-cwd>/*.jsonl
+ * for session files whose content contains the taskLogId.
  *
  * Claude encodes the cwd into a directory name by replacing : \ / . with -
+ * The JSONL filename (minus .jsonl) is the Claude session ID.
  */
-export function detectClaudeSession(cwd: string): AiSession | null {
+export function detectClaudeSession(cwd: string, taskLogId: string): AiSession | null {
   try {
     const encodedCwd = cwd.replace(/[:\\/\.]/g, '-');
     const projectDir = path.join(os.homedir(), '.claude', 'projects', encodedCwd);
@@ -64,27 +45,27 @@ export function detectClaudeSession(cwd: string): AiSession | null {
     const jsonlFiles = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
     if (jsonlFiles.length === 0) return null;
 
-    // Pick the most recently modified .jsonl — that's the latest session
-    let bestFile = '';
-    let bestMtime = 0;
-    for (const file of jsonlFiles) {
-      const stat = fs.statSync(path.join(projectDir, file));
-      if (stat.mtimeMs > bestMtime) {
-        bestMtime = stat.mtimeMs;
-        bestFile = file;
+    // Sort by mtime descending — check most recent first for efficiency
+    const sorted = jsonlFiles
+      .map(f => ({ name: f, mtime: fs.statSync(path.join(projectDir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+
+    for (const file of sorted) {
+      const content = fs.readFileSync(path.join(projectDir, file.name), 'utf-8');
+      if (contentMatchesTaskLogId(content, taskLogId)) {
+        const sessionId = file.name.replace('.jsonl', '');
+        return { source: 'claude', id: sessionId, resumable: true };
       }
     }
-
-    const sessionId = bestFile.replace('.jsonl', '');
-    return { source: 'claude', id: sessionId, resumable: true };
+    return null;
   } catch {
     return null;
   }
 }
 
 /**
- * Detect Copilot AI sessions by scanning ~/.copilot/session-state/
- * for sessions whose events.jsonl references the given taskLogId.
+ * Detect Copilot AI sessions by scanning ~/.copilot/session-state/{id}/events.jsonl
+ * for sessions whose content contains the taskLogId.
  */
 export function detectCopilotSession(taskLogId: string): AiSession | null {
   const sessionStateDir = path.join(os.homedir(), '.copilot', 'session-state');
@@ -96,9 +77,8 @@ export function detectCopilotSession(taskLogId: string): AiSession | null {
       const eventsPath = path.join(sessionStateDir, dir, 'events.jsonl');
       try {
         if (!fs.existsSync(eventsPath)) continue;
-        const eventsContent = fs.readFileSync(eventsPath, 'utf-8');
-        if (copilotEventsMatchTaskLogId(eventsContent, taskLogId)) {
-          // Found matching session — extract id from workspace.yaml
+        const content = fs.readFileSync(eventsPath, 'utf-8');
+        if (contentMatchesTaskLogId(content, taskLogId)) {
           const yamlPath = path.join(sessionStateDir, dir, 'workspace.yaml');
           if (fs.existsSync(yamlPath)) {
             const yamlContent = fs.readFileSync(yamlPath, 'utf-8');
@@ -107,11 +87,9 @@ export function detectCopilotSession(taskLogId: string): AiSession | null {
               return { source: 'copilot', id: sessionId, resumable: false };
             }
           }
-          // Fallback: use directory name as session id
           return { source: 'copilot', id: dir, resumable: false };
         }
       } catch {
-        // Skip unreadable session directories
         continue;
       }
     }
@@ -123,12 +101,13 @@ export function detectCopilotSession(taskLogId: string): AiSession | null {
 
 /**
  * Detect all AI sessions. Tries both Claude and Copilot adapters.
+ * Both use taskLogId matching on session log content.
  * Returns empty array on failure — never throws.
  */
 export function detectAiSessions(cwd: string, taskLogId: string): AiSession[] {
   const sessions: AiSession[] = [];
   try {
-    const claude = detectClaudeSession(cwd);
+    const claude = detectClaudeSession(cwd, taskLogId);
     if (claude) sessions.push(claude);
   } catch { /* graceful fallback */ }
   try {

--- a/src/session-index-manager.ts
+++ b/src/session-index-manager.ts
@@ -1,0 +1,206 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { detectAiSessions, AiSession } from './session-detector';
+
+/**
+ * Events that the SessionIndexManager listens to.
+ */
+export interface SessionCreatedEvent {
+  type: 'session_created';
+  repoSlug: string;
+  taskLogId: string;
+  sessionId: string;
+  cwd: string;
+}
+
+export interface SessionEndedEvent {
+  type: 'session_ended';
+  repoSlug: string;
+  taskLogId: string;
+  cwd: string;
+}
+
+export interface SessionDetectAiEvent {
+  type: 'session_detect_ai';
+  repoSlug: string;
+  taskLogId: string;
+  cwd: string;
+}
+
+export type SessionEvent = SessionCreatedEvent | SessionEndedEvent | SessionDetectAiEvent;
+
+/**
+ * Manages the global session index at ~/.squire/sessions/index.json.
+ *
+ * Listens to session lifecycle events from TaskRunner and keeps the index
+ * up to date. All file I/O for the session index lives here — TaskRunner
+ * only fires events.
+ */
+export class SessionIndexManager {
+  private static readonly INDEX_DIR = path.join(os.homedir(), '.squire', 'sessions');
+  private static readonly INDEX_PATH = path.join(SessionIndexManager.INDEX_DIR, 'index.json');
+
+  private static readonly AI_DETECT_INTERVAL = 10_000; // 10s between retries
+  private static readonly AI_DETECT_MAX_RETRIES = 12;  // up to 2 minutes
+  static generateSessionId(): string {
+    const ts = Date.now();
+    const rand = Math.random().toString(36).slice(2, 6).padEnd(4, '0');
+    return `dsq-${ts}-${rand}`;
+  }
+
+  private activePollers = new Map<string, ReturnType<typeof setInterval>>();
+
+  /** Handle a session lifecycle event */
+  handleEvent(event: SessionEvent): void {
+    switch (event.type) {
+      case 'session_created':
+        this.createSession(event.repoSlug, event.taskLogId, event.sessionId);
+        this.startAiDetectionPolling(event.repoSlug, event.taskLogId, event.cwd);
+        break;
+      case 'session_ended':
+        this.stopAiDetectionPolling(event.taskLogId);
+        this.endSession(event.repoSlug, event.taskLogId, event.cwd);
+        break;
+      case 'session_detect_ai':
+        // One-shot detect (backward compat, shouldn't normally be used)
+        this.detectAndWriteAiSessions(event.repoSlug, event.taskLogId, event.cwd);
+        break;
+    }
+  }
+
+  /** Read the index for a specific repo. Used by dashboard-provider. */
+  readRepoSessions(repoSlug: string): Record<string, { sessions: SessionRecord[] }> {
+    const index = this.readIndex();
+    return index[repoSlug] || {};
+  }
+
+  // --- Private ---
+
+  private createSession(repoSlug: string, taskLogId: string, sessionId: string): void {
+    try {
+      const index = this.readIndex();
+      if (!index[repoSlug]) index[repoSlug] = {};
+      if (!index[repoSlug][taskLogId]) index[repoSlug][taskLogId] = { sessions: [] };
+
+      const session: SessionRecord = {
+        id: sessionId,
+        startedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        endedAt: null,
+        aiSessions: [],
+      };
+      index[repoSlug][taskLogId].sessions.push(session);
+      this.writeIndex(index);
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private endSession(repoSlug: string, taskLogId: string, cwd: string): void {
+    try {
+      const index = this.readIndex();
+      const taskEntry = index[repoSlug]?.[taskLogId];
+      if (!taskEntry?.sessions?.length) return;
+
+      const latest = taskEntry.sessions[taskEntry.sessions.length - 1];
+      let changed = false;
+
+      // Detect AI sessions if not already set
+      if (!latest.aiSessions || latest.aiSessions.length === 0) {
+        const aiSessions = detectAiSessions(cwd, taskLogId);
+        if (aiSessions.length > 0) {
+          latest.aiSessions = aiSessions;
+          changed = true;
+        }
+      }
+
+      // Write endedAt
+      if (!latest.endedAt) {
+        latest.endedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+        changed = true;
+      }
+
+      if (changed) {
+        this.writeIndex(index);
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  /** @returns true if AI sessions were found */
+  private detectAndWriteAiSessions(repoSlug: string, taskLogId: string, cwd: string): boolean {
+    try {
+      const index = this.readIndex();
+      const taskEntry = index[repoSlug]?.[taskLogId];
+      if (!taskEntry?.sessions?.length) return false;
+
+      const latest = taskEntry.sessions[taskEntry.sessions.length - 1];
+      if (latest.aiSessions && latest.aiSessions.length > 0) return true; // Already detected
+
+      const aiSessions = detectAiSessions(cwd, taskLogId);
+      if (aiSessions.length > 0) {
+        latest.aiSessions = aiSessions;
+        this.writeIndex(index);
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Poll for AI session files every 10s until detected or max retries reached.
+   * Claude/Copilot session files may take time to appear on disk.
+   */
+  private startAiDetectionPolling(repoSlug: string, taskLogId: string, cwd: string): void {
+    // Stop any existing poller for this task
+    this.stopAiDetectionPolling(taskLogId);
+
+    let retries = 0;
+    const interval = setInterval(() => {
+      retries++;
+      const found = this.detectAndWriteAiSessions(repoSlug, taskLogId, cwd);
+      if (found || retries >= SessionIndexManager.AI_DETECT_MAX_RETRIES) {
+        this.stopAiDetectionPolling(taskLogId);
+      }
+    }, SessionIndexManager.AI_DETECT_INTERVAL);
+
+    this.activePollers.set(taskLogId, interval);
+  }
+
+  private stopAiDetectionPolling(taskLogId: string): void {
+    const interval = this.activePollers.get(taskLogId);
+    if (interval) {
+      clearInterval(interval);
+      this.activePollers.delete(taskLogId);
+    }
+  }
+
+  private readIndex(): Record<string, Record<string, { sessions: SessionRecord[] }>> {
+    try {
+      if (fs.existsSync(SessionIndexManager.INDEX_PATH)) {
+        return JSON.parse(fs.readFileSync(SessionIndexManager.INDEX_PATH, 'utf-8'));
+      }
+    } catch { /* corrupted — start fresh */ }
+    return {};
+  }
+
+  private writeIndex(index: Record<string, Record<string, { sessions: SessionRecord[] }>>): void {
+    try {
+      fs.mkdirSync(SessionIndexManager.INDEX_DIR, { recursive: true });
+      fs.writeFileSync(SessionIndexManager.INDEX_PATH, JSON.stringify(index, null, 2));
+    } catch {
+      // Non-critical
+    }
+  }
+}
+
+interface SessionRecord {
+  id: string;
+  startedAt: string;
+  endedAt: string | null;
+  aiSessions: AiSession[];
+}

--- a/src/sq-script.ts
+++ b/src/sq-script.ts
@@ -13,28 +13,15 @@
  */
 export const SQ_SCRIPT = `#!/usr/bin/env node
 import { writeFileSync, readFileSync, existsSync, appendFileSync, mkdirSync, unlinkSync } from 'fs';
-import { join, dirname, basename } from 'path';
-import { homedir } from 'os';
+import { join } from 'path';
 
 const [,, cmd, ...argv] = process.argv;
-
-function generateSessionId() {
-  const ts = Date.now();
-  const rand = Math.random().toString(36).slice(2, 6).padEnd(4, '0');
-  return \\\`dsq-\\\${ts}-\\\${rand}\\\`;
-}
-
-
-if (cmd === 'session-id') {
-  console.log(generateSessionId());
-  process.exit(0);
-}
 
 const squireDir = argv[0];
 const rest = argv.slice(1);
 
 if (!cmd || !squireDir) {
-  console.error('Usage: sq.mjs <log|decision|decision-clear|session-id> <squire-dir> ...');
+  console.error('Usage: sq.mjs <log|decision|decision-clear> <squire-dir> ...');
   process.exit(1);
 }
 
@@ -53,59 +40,6 @@ function parseFlags(args) {
     }
   }
   return { positional, flags };
-}
-
-// --- Session Index helpers ---
-const GLOBAL_SQUIRE_DIR = join(homedir(), '.squire');
-const SESSION_INDEX_DIR = join(GLOBAL_SQUIRE_DIR, 'sessions');
-const SESSION_INDEX_PATH = join(SESSION_INDEX_DIR, 'index.json');
-
-function readSessionIndex() {
-  try {
-    if (existsSync(SESSION_INDEX_PATH)) {
-      return JSON.parse(readFileSync(SESSION_INDEX_PATH, 'utf-8'));
-    }
-  } catch { /* corrupted — start fresh */ }
-  return {};
-}
-
-function writeSessionIndex(index) {
-  mkdirSync(SESSION_INDEX_DIR, { recursive: true });
-  writeFileSync(SESSION_INDEX_PATH, JSON.stringify(index, null, 2));
-}
-
-function deriveRepoSlug(sqDir) {
-  // Resolve the repo root from squireDir (handles worktree paths)
-  const normalized = sqDir.replace(/\\\\/g, '/');
-  const worktreeMatch = normalized.match(/^(.+?\\.squire)\\/worktrees\\//);
-  const rootSquire = worktreeMatch ? worktreeMatch[1] : normalized;
-  const repoRoot = dirname(rootSquire);
-  // Try to read repo slug from git remote
-  try {
-    const { execSync } = require('child_process');
-    const url = execSync('git remote get-url origin', { cwd: repoRoot, encoding: 'utf-8', timeout: 5000 }).trim();
-    const m = url.match(/github\\.com[/:](.+?)(?:\\.git)?$/);
-    if (m) return m[1];
-  } catch { /* fallback */ }
-  return basename(repoRoot);
-}
-
-function createSessionRecord(taskId, flags) {
-  const index = readSessionIndex();
-  const repo = deriveRepoSlug(squireDir);
-
-  if (!index[repo]) index[repo] = {};
-  if (!index[repo][taskId]) index[repo][taskId] = { sessions: [] };
-
-  const session = {
-    id: flags['session-id'] || generateSessionId(),
-    startedAt: ts,
-    endedAt: null,
-    aiSessions: [],
-  };
-  index[repo][taskId].sessions.push(session);
-
-  writeSessionIndex(index);
 }
 
 if (cmd === 'log') {
@@ -129,11 +63,6 @@ if (cmd === 'log') {
 
   mkdirSync(logsDir, { recursive: true });
   appendFileSync(join(logsDir, taskId + '.jsonl'), JSON.stringify(entry) + String.fromCharCode(10));
-
-  // Create session record in global index on session_start
-  if (eventType === 'session_start' || eventType === 'task_start') {
-    try { createSessionRecord(taskId, flags); } catch { /* non-critical */ }
-  }
 
 } else if (cmd === 'decision') {
   // sq.mjs decision <squire-dir> <task-id> <title> <options-csv>
@@ -176,7 +105,7 @@ if (cmd === 'log') {
   try { unlinkSync(join(decisionsDir, taskId + '.json')); } catch { /* ok if missing */ }
 
 } else {
-  console.error('Unknown command: ' + cmd + '. Use: log, decision, decision-clear, session-id');
+  console.error('Unknown command: ' + cmd + '. Use: log, decision, decision-clear');
   process.exit(1);
 }
 `;

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -377,6 +377,7 @@ export class TaskRunner {
       const terminal = task.terminal;
       // Clear reference first so onDidCloseTerminal won't double-process
       task.terminal = undefined;
+      task.status = 'completed';
       terminal.dispose();
       // Don't mark as completed — the issue isn't done, user just stopped the agent
       if (task.type !== 'watch-pr') {

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -56,18 +56,22 @@ export class TaskRunner {
     vscode.window.onDidCloseTerminal((closedTerminal) => {
       for (const task of this.tasks.values()) {
         if (task.terminal === closedTerminal) {
-          task.status = 'completed';
-          // Write done event to JSONL so dashboard shows completion
-          // Skip for cyclic pipelines (watch-pr) — they don't have a terminal "done" state
+          // If stopTask already marked it completed, just clean up the terminal reference
+          if (task.status === 'completed') {
+            task.terminal = undefined;
+            this._onTasksChanged.fire();
+            break;
+          }
+          // Terminal closed unexpectedly — don't change task status (user may have killed it mid-run)
+          // Keep current status so the task shows a Resume button instead of marking as done
           if (task.type !== 'watch-pr') {
             const taskLogId = task.taskLogId || `task-${task.id}`;
             this.squireDir.logJson(taskLogId, {
-              event: 'task_completed',
-              phase: 'done',
+              event: 'terminal_closed',
+              phase: 'paused',
               task_id: taskLogId,
               type: task.type,
             });
-            // Write endedAt + detect AI sessions (fallback for 30s delayed detection)
             const cwd = task.worktreeDir || this.workspaceRoot;
             this.updateSessionIndex(taskLogId, cwd, true);
           }

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -7,7 +7,7 @@ import { WorktreeManager } from './worktree';
 import { GitHubRepoInfo } from './github-detector';
 import { SquireDir } from './squire-dir';
 import { SquireBackend } from './backend';
-import { detectAiSessions } from './session-detector';
+import { SessionEvent, SessionIndexManager } from './session-index-manager';
 
 export type TaskType = 'dev-issue' | 'watch-pr' | 'review-pr' | 'fix-comments' | 'run-command' | 'run-agent';
 
@@ -46,6 +46,9 @@ export class TaskRunner {
   private _onTasksChanged = new vscode.EventEmitter<void>();
   readonly onTasksChanged = this._onTasksChanged.event;
 
+  private _onSessionEvent = new vscode.EventEmitter<SessionEvent>();
+  readonly onSessionEvent = this._onSessionEvent.event;
+
   constructor(
     private worktree: WorktreeManager,
     private workspaceRoot: string,
@@ -73,9 +76,15 @@ export class TaskRunner {
               type: task.type,
             });
             const cwd = task.worktreeDir || this.workspaceRoot;
-            this.updateSessionIndex(taskLogId, cwd, true);
+            this._onSessionEvent.fire({
+              type: 'session_ended',
+              repoSlug: this.repoSlug,
+              taskLogId,
+              cwd,
+            });
           }
           task.terminal = undefined;
+          task.status = 'completed'; // No longer running — allows re-run without "already running" warning
           this._onTasksChanged.fire();
           this.squireDir.log('extension', `Task ${task.id} (${task.label}) terminal closed`);
         }
@@ -329,26 +338,63 @@ export class TaskRunner {
     return undefined;
   }
 
+  /** Resume a Claude AI session: create terminal with `claude --resume`, bind it back to the task */
+  resumeSession(taskId: string, aiSessionId: string, worktreeDir?: string): void {
+    const cwd = worktreeDir || this.workspaceRoot;
+    const terminal = vscode.window.createTerminal({
+      name: `Resume: ${aiSessionId.slice(0, 8)}`,
+      cwd,
+      iconPath: new vscode.ThemeIcon('debug-restart'),
+    });
+    terminal.show(false);
+    terminal.sendText(`claude --resume "${aiSessionId}"`, true);
+
+    // Bind terminal back to existing task so it shows as running
+    const found = this.findTask(taskId);
+    if (found) {
+      const task = found[1];
+      task.terminal = terminal;
+      task.status = 'running';
+      this._onTasksChanged.fire();
+
+      // Fire session_created for the resumed session
+      const sessionId = SessionIndexManager.generateSessionId();
+      this._onSessionEvent.fire({
+        type: 'session_created',
+        repoSlug: this.repoSlug,
+        taskLogId: task.taskLogId || `task-${task.id}`,
+        sessionId,
+        cwd,
+      });
+    }
+  }
+
   /** Stop a running task: close terminal, mark completed */
   stopTask(taskId: string): void {
     const found = this.findTask(taskId);
     if (found?.[1]?.terminal) {
       const task = found[1];
-      task.terminal.dispose();
-      task.status = 'completed';
-      // Write completion event to JSONL + update session index
+      const terminal = task.terminal;
+      // Clear reference first so onDidCloseTerminal won't double-process
+      task.terminal = undefined;
+      terminal.dispose();
+      // Don't mark as completed — the issue isn't done, user just stopped the agent
       if (task.type !== 'watch-pr') {
         const taskLogId = task.taskLogId || `task-${task.id}`;
         this.squireDir.logJson(taskLogId, {
-          event: 'task_completed',
-          phase: 'done',
+          event: 'task_stopped',
+          phase: 'paused',
           task_id: taskLogId,
           type: task.type,
         });
         const cwd = task.worktreeDir || this.workspaceRoot;
-        this.updateSessionIndex(taskLogId, cwd, true);
+        this._onSessionEvent.fire({
+          type: 'session_ended',
+          repoSlug: this.repoSlug,
+          taskLogId,
+          cwd,
+        });
       }
-      task.terminal = undefined;
       this._onTasksChanged.fire();
       this.squireDir.log('extension', `Task ${taskId} stopped by user`);
     }
@@ -361,6 +407,8 @@ export class TaskRunner {
       const [runtimeId] = found;
       this.tasks.delete(runtimeId);
     }
+    // Write dismissed event to JSONL so log-only tasks are also hidden
+    this.squireDir.logJson(taskId, { event: 'task_dismissed' });
     this._onTasksChanged.fire();
     this.squireDir.log('extension', `Task ${taskId} dismissed`);
   }
@@ -556,12 +604,15 @@ export class TaskRunner {
     taskInfo.terminal = terminal;
     this._onTasksChanged.fire();
 
-    // Delayed AI session detection (30s after launch — session files need time to appear)
-    const delayedTaskLogId = taskInfo.taskLogId || `task-${taskInfo.id}`;
-    const delayedCwd = cwd;
-    setTimeout(() => {
-      this.updateSessionIndex(delayedTaskLogId, delayedCwd, false);
-    }, 30_000);
+    // Fire session_created event — SessionIndexManager handles the index write
+    const sessionId = SessionIndexManager.generateSessionId();
+    this._onSessionEvent.fire({
+      type: 'session_created',
+      repoSlug: this.repoSlug,
+      taskLogId: taskInfo.taskLogId || `task-${taskInfo.id}`,
+      sessionId,
+      cwd,
+    });
   }
 
   private formatDevLabel(mode: string, issueNum: string | null, title?: string, rawInput?: string): string {
@@ -581,43 +632,4 @@ export class TaskRunner {
     return null;
   }
 
-  /**
-   * Update the global session index (~/.squire/sessions/index.json).
-   * Detects AI sessions and optionally writes endedAt.
-   * @param writeEndedAt - true when called on terminal close, false for 30s delayed detection
-   */
-  private updateSessionIndex(taskLogId: string, cwd: string, writeEndedAt: boolean): void {
-    const indexPath = path.join(os.homedir(), '.squire', 'sessions', 'index.json');
-    try {
-      if (!fs.existsSync(indexPath)) return;
-      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-      const repoSlug = this.repoSlug;
-      const taskEntry = index[repoSlug]?.[taskLogId];
-      if (!taskEntry?.sessions?.length) return;
-
-      const latest = taskEntry.sessions[taskEntry.sessions.length - 1];
-      let changed = false;
-
-      // Detect AI sessions if not already set
-      if (!latest.aiSessions || latest.aiSessions.length === 0) {
-        const aiSessions = detectAiSessions(cwd, taskLogId);
-        if (aiSessions.length > 0) {
-          latest.aiSessions = aiSessions;
-          changed = true;
-        }
-      }
-
-      // Write endedAt on terminal close
-      if (writeEndedAt && !latest.endedAt) {
-        latest.endedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-        changed = true;
-      }
-
-      if (changed) {
-        fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
-      }
-    } catch {
-      // Non-critical — don't block terminal close
-    }
-  }
 }

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -156,6 +156,7 @@ export class TaskStateReader {
       const lines = content.trim().split('\n').filter(Boolean);
       const events: TaskEvent[] = [];
       let phase: TaskPhase = 'planned';
+      let dismissed = false;
       let branch: string | undefined;
       let prNumber: number | undefined;
       let prUrl: string | undefined;
@@ -183,6 +184,7 @@ export class TaskStateReader {
           if (entry.issue_number) issueNumber = entry.issue_number;
           if (entry.issue_url) issueUrl = entry.issue_url;
           if (entry.worktree_dir) worktreeDir = entry.worktree_dir;
+          if (entry.event === 'task_dismissed') dismissed = true;
 
           events.push({
             timestamp: entry.timestamp,
@@ -204,6 +206,8 @@ export class TaskStateReader {
       const filteredEvents = sessionId
         ? events.filter((e) => e.dsqSession === sessionId)
         : events;
+
+      if (dismissed) return null;
 
       return {
         id: taskId,

--- a/test/session-detector.test.ts
+++ b/test/session-detector.test.ts
@@ -1,55 +1,30 @@
 import { describe, it, expect } from 'vitest';
 import {
-  parseClaudeSessionFile,
+  contentMatchesTaskLogId,
   parseCopilotWorkspaceYaml,
-  copilotEventsMatchTaskLogId,
 } from '../src/session-detector';
 
 // --- Tests ---
 
 describe('Session Detector', () => {
-  describe('parseClaudeSessionFile', () => {
-    const validSession = JSON.stringify({
-      pid: 38440,
-      sessionId: '010eddef-3f05-4711-8270-ad465e88aad5',
-      cwd: 'C:\\Users\\alice\\project',
-      startedAt: 1777273077137,
-      version: '2.1.116',
+  describe('contentMatchesTaskLogId', () => {
+    it('returns true when taskLogId is in content', () => {
+      const content = '[task-log-id:task-issue-42] [squire-dir:/path]';
+      expect(contentMatchesTaskLogId(content, 'task-issue-42')).toBe(true);
     });
 
-    it('returns sessionId when cwd matches', () => {
-      expect(parseClaudeSessionFile(validSession, 'C:\\Users\\alice\\project'))
-        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
+    it('returns true in multiline JSONL content', () => {
+      const content = '{"type":"user.message","data":{"content":"do stuff [task-log-id:task-issue-42]"}}\n{"type":"done"}';
+      expect(contentMatchesTaskLogId(content, 'task-issue-42')).toBe(true);
     });
 
-    it('matches cwd case-insensitively', () => {
-      expect(parseClaudeSessionFile(validSession, 'c:\\users\\alice\\project'))
-        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
+    it('returns false when taskLogId is not found', () => {
+      const content = '{"event":"start","task":"task-issue-99"}';
+      expect(contentMatchesTaskLogId(content, 'task-issue-42')).toBe(false);
     });
 
-    it('normalizes slashes for comparison', () => {
-      expect(parseClaudeSessionFile(validSession, 'C:/Users/alice/project'))
-        .toBe('010eddef-3f05-4711-8270-ad465e88aad5');
-    });
-
-    it('returns null when cwd does not match', () => {
-      expect(parseClaudeSessionFile(validSession, '/other/path')).toBeNull();
-    });
-
-    it('returns null for missing sessionId', () => {
-      expect(parseClaudeSessionFile('{"cwd":"/a"}', '/a')).toBeNull();
-    });
-
-    it('returns null for missing cwd', () => {
-      expect(parseClaudeSessionFile('{"sessionId":"abc"}', '/a')).toBeNull();
-    });
-
-    it('returns null for invalid JSON', () => {
-      expect(parseClaudeSessionFile('not json', '/a')).toBeNull();
-    });
-
-    it('returns null for empty string', () => {
-      expect(parseClaudeSessionFile('', '/a')).toBeNull();
+    it('returns false for empty content', () => {
+      expect(contentMatchesTaskLogId('', 'task-issue-42')).toBe(false);
     });
   });
 
@@ -72,22 +47,6 @@ summary: Review PR 123`;
 
     it('returns null for empty string', () => {
       expect(parseCopilotWorkspaceYaml('')).toBeNull();
-    });
-  });
-
-  describe('copilotEventsMatchTaskLogId', () => {
-    it('returns true when taskLogId is in content', () => {
-      const events = '{"event":"start","task":"task-issue-42"}\n{"event":"done"}';
-      expect(copilotEventsMatchTaskLogId(events, 'task-issue-42')).toBe(true);
-    });
-
-    it('returns false when taskLogId is not found', () => {
-      const events = '{"event":"start","task":"task-issue-99"}';
-      expect(copilotEventsMatchTaskLogId(events, 'task-issue-42')).toBe(false);
-    });
-
-    it('returns false for empty content', () => {
-      expect(copilotEventsMatchTaskLogId('', 'task-issue-42')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Task grouping**: Group tasks by Issues / PRs with per-item collapsible sections, adhoc tasks also collapsible
- **Session labels**: Show session history with timestamps and resume buttons
- **Terminal kill behavior**: Properly set task status to completed on terminal close/stop
- **Button fixes**: Fix HTML attribute quoting in Dismiss/Clean buttons, missing paren in confirmAction
- **Session index management**: Move `~/.squire/sessions/index.json` from LLM (sq.mjs) to VS Code extension via event-driven `SessionIndexManager`
- **AI session detection**: Poll for Claude/Copilot session files (10s interval, up to 2min) instead of one-shot 30s timeout
- **Claude session detection**: Scan `~/.claude/projects/<encoded-cwd>/` for JSONL files instead of matching by cwd in session JSON
- **Resume session**: Restore task to running state, bind new terminal, fire session events
- **sq.mjs cleanup**: Remove session-id command and session index writes, keep task-level logging

## Test plan
- [ ] Run dev-issue → verify phases update in dashboard
- [ ] Stop task → verify status shows completed with resume option
- [ ] Resume session → verify task returns to running state
- [ ] Check `~/.squire/sessions/index.json` is populated by extension only
- [ ] Verify no `sq.mjs session-id` calls in terminal output
- [ ] PR review tasks group by PR number
- [ ] Adhoc tasks have collapse button

🤖 Generated with [Claude Code](https://claude.com/claude-code)