### PR TITLE
fix: restore worktree button after resuming session on extension restart

### DIFF
--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -361,13 +361,36 @@ export class TaskRunner {
     terminal.sendText(resumeCmd, true);
 
     // Bind terminal back to existing task so it shows as running
-    const found = this.findTask(taskId);
+    let found = this.findTask(taskId);
     const sessionId = SessionIndexManager.generateSessionId();
+
+    // Extension may have restarted — task only exists in JSONL logs, not in memory.
+    // Re-create the in-memory TaskInfo so the dashboard shows hasTerminal / worktreeDir.
+    if (!found) {
+      const runtimeId = `resumed-${Date.now()}`;
+      const task: TaskInfo = {
+        id: runtimeId,
+        taskLogId: taskId,
+        type: 'dev-issue',
+        label: `Resumed: ${taskId}`,
+        worktreeDir,
+        worktreeBranch: worktreeDir ? worktreeDir.split('/').pop() : undefined,
+        status: 'running',
+        terminal,
+        sessionIds: [sessionId],
+        createdAt: Date.now(),
+      };
+      this.tasks.set(runtimeId, task);
+      found = [runtimeId, task];
+    }
+
     if (found) {
       const task = found[1];
       task.terminal = terminal;
       task.status = 'running';
-      task.sessionIds.push(sessionId);
+      if (!task.sessionIds.includes(sessionId)) task.sessionIds.push(sessionId);
+      // Restore worktreeDir if it was lost (e.g. task was in memory but without worktreeDir)
+      if (!task.worktreeDir && worktreeDir) task.worktreeDir = worktreeDir;
       this._onTasksChanged.fire();
       this._onSessionEvent.fire({
         type: 'session_created',


### PR DESCRIPTION
## Summary
- When the extension restarts, the in-memory `tasks` Map is empty. `resumeSession()` failed to find the task via `findTask()`, so `hasTerminal`, `worktreeDir`, and `status` were never set — hiding the Worktree button.
- Re-create the `TaskInfo` in memory when `findTask` returns nothing, reusing the existing worktree directory from the JSONL log.
- Also restore `worktreeDir` on existing in-memory tasks if it was lost.

Closes [#93](https://github.com/frankliu20/DevSquire/issues/93)

## Test plan
- [ ] Start a dev-issue task (non-chat mode) so a worktree is created
- [ ] Close and reopen VS Code (extension restarts)
- [ ] Resume the session from the dashboard
- [ ] Verify the Worktree button appears on the task card

🤖 Generated with [Claude Code](https://claude.com/claude-code)