### PR TITLE
fix: use stdin for scrum GitHub comments to preserve newlines

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -168,8 +168,8 @@ export class ReportGenerator {
       const body = `${date} status update:\n[${status}] #${issue.number} ${issue.title}${prLink}`;
       try {
         cp.execSync(
-          `gh issue comment ${issue.number} --repo ${this.slug} --body "${body.replace(/"/g, '\\"')}"`,
-          { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] },
+          `gh issue comment ${issue.number} --repo ${this.slug} --body-file -`,
+          { encoding: 'utf-8', timeout: 10000, input: body, stdio: ['pipe', 'pipe', 'pipe'] },
         );
       } catch { /* ignore */ }
     }


### PR DESCRIPTION
## Summary
- Scrum "Post to GitHub" was only posting the first line (`2026-04-29 status update:`) — the status, issue number, and title were lost
- Root cause: multi-line body interpolated into a shell `--body "..."` argument; the newline broke the command
- Fix: switch to `--body-file -` with `input` option to pass body via stdin

Closes [#95](https://github.com/frankliu20/DevSquire/issues/95)

## Test plan
- [ ] Open Scrum report tab with at least one done/ongoing/blocked issue
- [ ] Click "Post to GitHub"
- [ ] Verify the full comment is posted on each issue (date line + status line + optional PR link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)