### PR TITLE
fix(dashboard): retain webview context when hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
         {
           "type": "webview",
           "id": "devSquire.dashboard",
-          "name": "Dashboard"
+          "name": "Dashboard",
+          "retainContextWhenHidden": true
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Add `retainContextWhenHidden: true` to the dashboard webview view declaration in `package.json`
- Prevents the webview from being destroyed/recreated when switching tabs, reducing race conditions

## Test plan
- [ ] Open DevSquire dashboard, switch to another tab, switch back — webview state should be preserved
- [ ] Verify no regression in dashboard functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)